### PR TITLE
New account variable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.10.8",
+    "version": "6.10.10",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.10.9",
+    "version": "6.10.10",
     "description": "Write everything faster.",
     "main": "index.js",
     "scripts": {

--- a/src/content/js/utils.js
+++ b/src/content/js/utils.js
@@ -222,8 +222,20 @@ function replaceFrom (from, setting) {
 }
 
 export function parseTemplate (template = '', data = {}) {
+    const nameSetting = window.App.settings.cache.name || {
+        firstName: '',
+        lastName: ''
+    };
     // get "from" name from settings
-    data.from = replaceFrom(data.from || {}, window.App.settings.cache.name);
+    data.from = replaceFrom(data.from || {}, nameSetting);
+
+    // account variable
+    data.account = {
+        name: `${nameSetting.firstName} ${nameSetting.lastName}`,
+        first_name: nameSetting.firstName,
+        last_name: nameSetting.lastName,
+        email: window.App.settings.cache.email
+    };
 
     return Handlebars.compile(template)(PrepareVars(data));
 }

--- a/src/store/plugin-firestore.js
+++ b/src/store/plugin-firestore.js
@@ -510,6 +510,7 @@ var getSettings = (params = {}) => {
                         // map to old format
                         cachedSettings = Object.assign({}, localSettings, {
                             name: splitFullName(userData.full_name),
+                            email: userData.email,
                             keyboard: {
                                 enabled: settings.expand_enabled,
                                 shortcut: settings.expand_shortcut


### PR DESCRIPTION
#### Changes:

- New `{{account}}` variable to get the details of your Gorgias Templates account: `account.name`, `account.first_name`, `account.last_name`, `account.email`.
- The use case is when you use multiple extension accounts on a single Gmail account.
- Some users relied on the previously-broken Gmail functionality when we were unable to get `{{from}}` data, and used data from the account instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-templates/410)
<!-- Reviewable:end -->
