### PR TITLE
Slate editor support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gorgias",
-    "version": "6.11.0",
+    "version": "6.12.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "gorgias",
-            "version": "6.11.0",
+            "version": "6.12.0",
             "license": "MIT",
             "dependencies": {
                 "bootstrap": "^4.5.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3109,9 +3109,9 @@
             }
         },
         "node_modules/mini-css-extract-plugin": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.4.0.tgz",
-            "integrity": "sha512-DyQr5DhXXARKZoc4kwvCvD95kh69dUupfuKOmBUqZ4kBTmRaRZcU32lYu3cLd6nEGXhQ1l7LzZ3F/CjItaY6VQ==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.4.1.tgz",
+            "integrity": "sha512-COAGbpAsU0ioFzj+/RRfO5Qv177L1Z/XAx2EmCF33b8GDDqKygMffBTws2lit8iaPdrbKEY5P+zsseBUCREZWQ==",
             "dev": true,
             "dependencies": {
                 "loader-utils": "^2.0.0",
@@ -7231,9 +7231,9 @@
             "dev": true
         },
         "mini-css-extract-plugin": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.4.0.tgz",
-            "integrity": "sha512-DyQr5DhXXARKZoc4kwvCvD95kh69dUupfuKOmBUqZ4kBTmRaRZcU32lYu3cLd6nEGXhQ1l7LzZ3F/CjItaY6VQ==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.4.1.tgz",
+            "integrity": "sha512-COAGbpAsU0ioFzj+/RRfO5Qv177L1Z/XAx2EmCF33b8GDDqKygMffBTws2lit8iaPdrbKEY5P+zsseBUCREZWQ==",
             "dev": true,
             "requires": {
                 "loader-utils": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,15 +47,15 @@
             }
         },
         "node_modules/@firebase/analytics": {
-            "version": "0.6.7",
-            "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.7.tgz",
-            "integrity": "sha512-ObnFDewIqiamvU7UKDx+0jfLrD3LyqEIsXZdjnGQhY/xc10HFH0jp23lOzb39CWf/399X+xMMJ3Uj51VyHwbJQ==",
+            "version": "0.6.9",
+            "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.9.tgz",
+            "integrity": "sha512-G0PkfMq/4tpDXwk/S2LKrXUWiz5tpQ6o2Lf6esgdEcDLpimPl32TrioNkDEDz8Xp0mzpY04UKwvYjT5xuzoKug==",
             "dependencies": {
                 "@firebase/analytics-types": "0.4.0",
-                "@firebase/component": "0.3.1",
-                "@firebase/installations": "0.4.23",
+                "@firebase/component": "0.4.1",
+                "@firebase/installations": "0.4.25",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.4.1",
+                "@firebase/util": "1.0.0",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
@@ -69,23 +69,23 @@
             "integrity": "sha512-Jj2xW+8+8XPfWGkv9HPv/uR+Qrmq37NPYT352wf7MvE9LrstpLVmFg3LqG6MCRr5miLAom5sen2gZ+iOhVDeRA=="
         },
         "node_modules/@firebase/app": {
-            "version": "0.6.18",
-            "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.18.tgz",
-            "integrity": "sha512-eBThPc4QGHy/FC+oHZsnp4Qk6oksYTZ10B4jXaVH1lCS5eUSKvV1TIzAtpkPzMp2huS/qBz411r1tkQUv5vKcw==",
+            "version": "0.6.20",
+            "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.20.tgz",
+            "integrity": "sha512-5zstJ3Cxw9H5cxfdaAhCH7WHVaRLPhCcgVNwKp6dWeTx2QkIdNvHainX8Vr2RaZchw4MxRjkPfwNVOaq2oFStQ==",
             "dependencies": {
-                "@firebase/app-types": "0.6.1",
-                "@firebase/component": "0.3.1",
+                "@firebase/app-types": "0.6.2",
+                "@firebase/component": "0.4.1",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.4.1",
+                "@firebase/util": "1.0.0",
                 "dom-storage": "2.1.0",
                 "tslib": "^2.1.0",
                 "xmlhttprequest": "1.8.0"
             }
         },
         "node_modules/@firebase/app-types": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.1.tgz",
-            "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.2.tgz",
+            "integrity": "sha512-2VXvq/K+n8XMdM4L2xy5bYp2ZXMawJXluUIDzUBvMthVR+lhxK4pfFiqr1mmDbv9ydXvEAuFsD+6DpcZuJcSSw=="
         },
         "node_modules/@firebase/auth": {
             "version": "0.16.4",
@@ -107,7 +107,7 @@
                 "@firebase/util": "0.x"
             }
         },
-        "node_modules/@firebase/auth-types": {
+        "node_modules/@firebase/auth/node_modules/@firebase/auth-types": {
             "version": "0.10.2",
             "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.2.tgz",
             "integrity": "sha512-0GMWVWh5TBCYIQfVerxzDsuvhoFpK0++O9LtP3FWkwYo7EAxp6w0cftAg/8ntU1E5Wg56Ry0b6ti/YGP6g0jlg==",
@@ -116,46 +116,55 @@
                 "@firebase/util": "0.x"
             }
         },
-        "node_modules/@firebase/component": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.3.1.tgz",
-            "integrity": "sha512-8ACaB772bWwZRE47aVEYzld+jlDPgvHnLZoiVtG6BzygonVnKzwXo0wK6wcRzCbx4kun7G/gXYM0gUMkqvKtRA==",
+        "node_modules/@firebase/auth/node_modules/@firebase/util": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.4.1.tgz",
+            "integrity": "sha512-XhYCOwq4AH+YeQBEnDQvigz50WiiBU4LnJh2+//VMt4J2Ybsk0eTgUHNngUzXsmp80EJrwal3ItODg55q1ajWg==",
+            "peer": true,
             "dependencies": {
-                "@firebase/util": "0.4.1",
+                "tslib": "^2.1.0"
+            }
+        },
+        "node_modules/@firebase/component": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.4.1.tgz",
+            "integrity": "sha512-f0IbIsoe33QzOj554rmDL04PyeZX/nNZYOAwlTzKmHq/JoFN6YoySi+0ZLyCtFrnRgw6zNnR/POXKOdfljWqZA==",
+            "dependencies": {
+                "@firebase/util": "1.0.0",
                 "tslib": "^2.1.0"
             }
         },
         "node_modules/@firebase/database": {
-            "version": "0.9.7",
-            "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.9.7.tgz",
-            "integrity": "sha512-JUm6CnUxFRuyWvzTAzv/Mo/KYwLtUezpNGa4AzbhbdS8t3ewprc/7ARFErpv95cIM5MgiiPcLOC5F+mLDmrQwA==",
+            "version": "0.9.10",
+            "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.9.10.tgz",
+            "integrity": "sha512-QvKhWpsBK4T1L4iGOpTBRvw4s2nqEtD6qja+L116BejFFJZik+U+cVe3xLKoeyGy2YtbcS28ly0h285pmnYwRw==",
             "dependencies": {
                 "@firebase/auth-interop-types": "0.1.5",
-                "@firebase/component": "0.3.1",
-                "@firebase/database-types": "0.7.0",
+                "@firebase/component": "0.4.1",
+                "@firebase/database-types": "0.7.2",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.4.1",
+                "@firebase/util": "1.0.0",
                 "faye-websocket": "0.11.3",
                 "tslib": "^2.1.0"
             }
         },
         "node_modules/@firebase/database-types": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.0.tgz",
-            "integrity": "sha512-FduQmPpUUOHgbOt7/vWlC1ntSLMEqqYessdQ/ODd7RFWm53iVa0T1mpIDtNwqd8gW3k7cajjSjcLjfQGtvLGDg==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.2.tgz",
+            "integrity": "sha512-cdAd/dgwvC0r3oLEDUR+ULs1vBsEvy0b27nlzKhU6LQgm9fCDzgaH9nFGv8x+S9dly4B0egAXkONkVoWcOAisg==",
             "dependencies": {
-                "@firebase/app-types": "0.6.1"
+                "@firebase/app-types": "0.6.2"
             }
         },
         "node_modules/@firebase/firestore": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.2.2.tgz",
-            "integrity": "sha512-tFB0gRZcYQ8y9WBO5cSCij8pspF4vv2NdUkG8qWKG9cx2ccXnjo3qiQWRkoLuJGPaicCOGt11c08KvNSy/zfDA==",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.2.4.tgz",
+            "integrity": "sha512-0B4WNVYDusxURRclHHjw/OBLad7gerr25QGljQ0kkpeFEd6bYyoTUeGtP6YlYYog8KhxsR9R5f0NacuzQPS4OA==",
             "dependencies": {
-                "@firebase/component": "0.3.1",
+                "@firebase/component": "0.4.1",
                 "@firebase/firestore-types": "2.2.0",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.4.1",
+                "@firebase/util": "1.0.0",
                 "@firebase/webchannel-wrapper": "0.4.1",
                 "@grpc/grpc-js": "^1.0.0",
                 "@grpc/proto-loader": "^0.5.0",
@@ -179,11 +188,11 @@
             }
         },
         "node_modules/@firebase/functions": {
-            "version": "0.6.5",
-            "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.5.tgz",
-            "integrity": "sha512-8T/BKscHJhzQ7cM9Kn2Hcs8mkA1Zypzvo4b0mue7hRm6W/vzDMsgTiAUk7j7H1HEEf1Saw58h2tlQBg2rdDHPQ==",
+            "version": "0.6.7",
+            "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.7.tgz",
+            "integrity": "sha512-IDw2ww28Tj8t947ySVO9wHghlwNl4bIUo5tPUzAbipfgLlj3GeHwqhvSv++O/ILBu4Rk7KD7cbxtw/rziATHNA==",
             "dependencies": {
-                "@firebase/component": "0.3.1",
+                "@firebase/component": "0.4.1",
                 "@firebase/functions-types": "0.4.0",
                 "@firebase/messaging-types": "0.5.0",
                 "node-fetch": "2.6.1",
@@ -200,13 +209,13 @@
             "integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ=="
         },
         "node_modules/@firebase/installations": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.23.tgz",
-            "integrity": "sha512-vULPhK0DbDcXL0utJ8Td8+x5ArpUjSbCarz5ttR+u3Xsn1sEC6EX2Tlmua6csqNnBU/VpMo1bopWOvCVyX9jYA==",
+            "version": "0.4.25",
+            "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.25.tgz",
+            "integrity": "sha512-szQ2bpI5NHTRuZAqXNZLq7bkZ1iTURPmojj7xWjBRxyMnDd6lLQ/Ht8Wut0ESH7uzbFNqmZ9oBMh2U9fpBIniA==",
             "dependencies": {
-                "@firebase/component": "0.3.1",
+                "@firebase/component": "0.4.1",
                 "@firebase/installations-types": "0.3.4",
-                "@firebase/util": "0.4.1",
+                "@firebase/util": "1.0.0",
                 "idb": "3.0.2",
                 "tslib": "^2.1.0"
             },
@@ -229,14 +238,14 @@
             "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw=="
         },
         "node_modules/@firebase/messaging": {
-            "version": "0.7.7",
-            "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.7.tgz",
-            "integrity": "sha512-osS61riot7Kg3YPuQWGqxOHos+IXOrTvTdchFOU/HVxenwmXteOpepEeNC3PZvudnYSKoI/w6voo5+E5yUyftw==",
+            "version": "0.7.9",
+            "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.9.tgz",
+            "integrity": "sha512-zzEmtpBdauT0n0JA5eN/dHeQZkQj/bbfl7CNmhA0EpKU2wTRFZCJYAOZkZEw8OD9/D/aDRcEk3Qq+5I1XcugZA==",
             "dependencies": {
-                "@firebase/component": "0.3.1",
-                "@firebase/installations": "0.4.23",
+                "@firebase/component": "0.4.1",
+                "@firebase/installations": "0.4.25",
                 "@firebase/messaging-types": "0.5.0",
-                "@firebase/util": "0.4.1",
+                "@firebase/util": "1.0.0",
                 "idb": "3.0.2",
                 "tslib": "^2.1.0"
             },
@@ -254,15 +263,15 @@
             }
         },
         "node_modules/@firebase/performance": {
-            "version": "0.4.9",
-            "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.9.tgz",
-            "integrity": "sha512-2BozmCAbvL4iFZwHE+9xSrdl3sJeF1/l8X2Ci4n8n+vwZjQbhq5pHPSZXLVT78i23V3XM14eS4SUJVqNL/QkRw==",
+            "version": "0.4.11",
+            "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.11.tgz",
+            "integrity": "sha512-SQb9QpAkgpPS1QnRLxNAXFTCrW/VT9MidVcJVHuBrCCW9sYY+QVuuWYpaGR4zQDsTx2e/UGUXJgw+z0vaQ0Q6w==",
             "dependencies": {
-                "@firebase/component": "0.3.1",
-                "@firebase/installations": "0.4.23",
+                "@firebase/component": "0.4.1",
+                "@firebase/installations": "0.4.25",
                 "@firebase/logger": "0.2.6",
                 "@firebase/performance-types": "0.0.13",
-                "@firebase/util": "0.4.1",
+                "@firebase/util": "1.0.0",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
@@ -286,15 +295,15 @@
             }
         },
         "node_modules/@firebase/remote-config": {
-            "version": "0.1.34",
-            "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.34.tgz",
-            "integrity": "sha512-4dXdRjwuTH8lckmF8bPYCq0P/fM3NLV9QAF98Anft7f/0ZZNAucyQpvlK8KP7IRBZcllXq1Rla4THCNFtrLLOA==",
+            "version": "0.1.36",
+            "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.36.tgz",
+            "integrity": "sha512-aQXaBDkEzFix3ycjPiP+4OPSXZmUbFunOiVi20XS9kRZrZfNhCH3HdBYwL1Nl9/AvcOnlZfX+lqa2LuHVXmuwA==",
             "dependencies": {
-                "@firebase/component": "0.3.1",
-                "@firebase/installations": "0.4.23",
+                "@firebase/component": "0.4.1",
+                "@firebase/installations": "0.4.25",
                 "@firebase/logger": "0.2.6",
                 "@firebase/remote-config-types": "0.1.9",
-                "@firebase/util": "0.4.1",
+                "@firebase/util": "1.0.0",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
@@ -308,13 +317,13 @@
             "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA=="
         },
         "node_modules/@firebase/storage": {
-            "version": "0.4.6",
-            "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.6.tgz",
-            "integrity": "sha512-nXhLuPKGJlty2whW56T5/Kpr/3O+cKSB5YcCcRKUO8eBu/1VvIswPgipWFaIpgZ3hkXJqaNzYLYpTdIf1UPWrQ==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.5.0.tgz",
+            "integrity": "sha512-nwIDikLEVzamuheZSRQbUbmMDITkPclCIokHR+4YbZsNNf7ukVN6PB8V/C8KMTjpDjSn9BOZbd9jF2U1VIgYqQ==",
             "dependencies": {
-                "@firebase/component": "0.3.1",
-                "@firebase/storage-types": "0.3.13",
-                "@firebase/util": "0.4.1",
+                "@firebase/component": "0.4.1",
+                "@firebase/storage-types": "0.4.0",
+                "@firebase/util": "1.0.0",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
@@ -323,18 +332,18 @@
             }
         },
         "node_modules/@firebase/storage-types": {
-            "version": "0.3.13",
-            "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.13.tgz",
-            "integrity": "sha512-pL7b8d5kMNCCL0w9hF7pr16POyKkb3imOW7w0qYrhBnbyJTdVxMWZhb0HxCFyQWC0w3EiIFFmxoz8NTFZDEFog==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.4.0.tgz",
+            "integrity": "sha512-2xgiLGfDv6Fz5qRrsO47/7PfbV9P+5tEuvEktJYTNxrgTxGPj3sMb7ZkycIb4JE98fAbmGEeMQaRSorqR5bEIQ==",
             "peerDependencies": {
                 "@firebase/app-types": "0.x",
-                "@firebase/util": "0.x"
+                "@firebase/util": "1.x"
             }
         },
         "node_modules/@firebase/util": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.4.1.tgz",
-            "integrity": "sha512-XhYCOwq4AH+YeQBEnDQvigz50WiiBU4LnJh2+//VMt4J2Ybsk0eTgUHNngUzXsmp80EJrwal3ItODg55q1ajWg==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.0.0.tgz",
+            "integrity": "sha512-KIEyuyrYKKtit+lAl66c2GVvooM1Pb+Yw/9yuSga1HKYMxNZwSsIMXU8X97sLZf7WJaanV1XNJEMkZTw3xKEoA==",
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -467,9 +476,9 @@
             "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
         },
         "node_modules/@types/eslint": {
-            "version": "7.2.8",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.8.tgz",
-            "integrity": "sha512-RTKvBsfz0T8CKOGZMfuluDNyMFHnu5lvNr4hWEsQeHXH6FcmIDIozOyWMh36nLGMwVd5UFNXC2xztA8lln22MQ==",
+            "version": "7.2.9",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.9.tgz",
+            "integrity": "sha512-SdAAXZNvWfhtf3X3y1cbbCZhP3xyPh7mfTvzV6CgfWc/ZhiHpyr9bVroe2/RCHIf7gczaNcprhaBLsx0CCJHQA==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -730,9 +739,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
-            "integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.1.tgz",
+            "integrity": "sha512-xYiIVjNuqtKXMxlRMDc6mZUhXehod4a3gbZ1qRlM7icK4EbxUFNLhWoPblCvFtB2Y9CIqHP3CF/rdxLItaQv8g==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -1129,16 +1138,16 @@
             "dev": true
         },
         "node_modules/browserslist": {
-            "version": "4.16.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-            "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+            "version": "4.16.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz",
+            "integrity": "sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==",
             "dev": true,
             "dependencies": {
-                "caniuse-lite": "^1.0.30001181",
-                "colorette": "^1.2.1",
-                "electron-to-chromium": "^1.3.649",
+                "caniuse-lite": "^1.0.30001208",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.712",
                 "escalade": "^3.1.1",
-                "node-releases": "^1.1.70"
+                "node-releases": "^1.1.71"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -1208,9 +1217,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001207",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz",
-            "integrity": "sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw==",
+            "version": "1.0.30001208",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
+            "integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==",
             "dev": true
         },
         "node_modules/chai": {
@@ -1295,22 +1304,13 @@
             "dev": true
         },
         "node_modules/chrome-trace-event": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
-            "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+            "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
             "dev": true,
-            "dependencies": {
-                "tslib": "^1.9.0"
-            },
             "engines": {
                 "node": ">=6.0"
             }
-        },
-        "node_modules/chrome-trace-event/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
         },
         "node_modules/cli": {
             "version": "1.0.1",
@@ -1539,9 +1539,9 @@
             }
         },
         "node_modules/css-loader": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.0.tgz",
-            "integrity": "sha512-MfRo2MjEeLXMlUkeUwN71Vx5oc6EJnx5UQ4Yi9iUtYQvrPtwLUucYptz0hc6n++kdNcyF5olYBS4vPjJDAcLkw==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.1.tgz",
+            "integrity": "sha512-YCyRzlt/jgG1xanXZDG/DHqAueOtXFHeusP9TS478oP1J++JSKOyEgGW1GHVoCj/rkS+GWOlBwqQJBr9yajQ9w==",
             "dev": true,
             "dependencies": {
                 "camelcase": "^6.2.0",
@@ -1656,9 +1656,9 @@
             }
         },
         "node_modules/dom-serializer": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
-            "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
+            "integrity": "sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==",
             "dependencies": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^4.0.0",
@@ -1702,9 +1702,9 @@
             }
         },
         "node_modules/domutils": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.1.tgz",
-            "integrity": "sha512-hO1XwHMGAthA/1KL7c83oip/6UWo3FlUNIuWiWKltoiQ5oCOiqths8KknvY2jpOohUoUgnwa/+Rm7UpwpSbY/Q==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.2.tgz",
+            "integrity": "sha512-MHTthCb1zj8f1GVfRpeZUbohQf/HdBos0oX5gZcQFepOZPLLRyj6Wn7XS7EMnY7CVpwv8863u2vyE83Hfu28HQ==",
             "dependencies": {
                 "dom-serializer": "^1.0.1",
                 "domelementtype": "^2.2.0",
@@ -1723,9 +1723,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.3.709",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.709.tgz",
-            "integrity": "sha512-LolItk2/ikSGQ7SN8UkuKVNMBZp3RG7Itgaxj1npsHRzQobj9JjMneZOZfLhtwlYBe5fCJ75k+cVCiDFUs23oA==",
+            "version": "1.3.713",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.713.tgz",
+            "integrity": "sha512-HWgkyX4xTHmxcWWlvv7a87RHSINEcpKYZmDMxkUlHcY+CJcfx7xEfBHuXVsO1rzyYs1WQJ7EgDp2CoErakBIow==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -2089,24 +2089,24 @@
             }
         },
         "node_modules/firebase": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.3.2.tgz",
-            "integrity": "sha512-qGKASp6lXcV8NriHz/3wdltyLUjHOVkON6TQ1syGjW0sS5q/yTl9LK4O83hDLwG+UeRVRhLOaVa3jaLG4o3gnw==",
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.4.1.tgz",
+            "integrity": "sha512-PMDt9iU8ry5P7PSrGQ+72O1gkfa5rNAeybMZhP22nKOh40sVozSkcKGZAFumXog7tjlslHJhUEZgfZbKCNkC8Q==",
             "dependencies": {
-                "@firebase/analytics": "0.6.7",
-                "@firebase/app": "0.6.18",
-                "@firebase/app-types": "0.6.1",
+                "@firebase/analytics": "0.6.9",
+                "@firebase/app": "0.6.20",
+                "@firebase/app-types": "0.6.2",
                 "@firebase/auth": "0.16.4",
-                "@firebase/database": "0.9.7",
-                "@firebase/firestore": "2.2.2",
-                "@firebase/functions": "0.6.5",
-                "@firebase/installations": "0.4.23",
-                "@firebase/messaging": "0.7.7",
-                "@firebase/performance": "0.4.9",
+                "@firebase/database": "0.9.10",
+                "@firebase/firestore": "2.2.4",
+                "@firebase/functions": "0.6.7",
+                "@firebase/installations": "0.4.25",
+                "@firebase/messaging": "0.7.9",
+                "@firebase/performance": "0.4.11",
                 "@firebase/polyfill": "0.3.36",
-                "@firebase/remote-config": "0.1.34",
-                "@firebase/storage": "0.4.6",
-                "@firebase/util": "0.4.1"
+                "@firebase/remote-config": "0.1.36",
+                "@firebase/storage": "0.5.0",
+                "@firebase/util": "1.0.0"
             },
             "engines": {
                 "node": "^8.13.0 || >=10.10.0"
@@ -2407,9 +2407,9 @@
             }
         },
         "node_modules/htmlparser2": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.0.1.tgz",
-            "integrity": "sha512-GDKPd+vk4jvSuvCbyuzx/unmXkk090Azec7LovXP8as1Hn8q9p3hbjmDGbUqqhknw0ajwit6LiiWqfiTUPMK7w==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+            "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
                 {
@@ -2420,7 +2420,7 @@
             "dependencies": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^4.0.0",
-                "domutils": "^2.4.4",
+                "domutils": "^2.5.2",
                 "entities": "^2.0.0"
             }
         },
@@ -3054,16 +3054,16 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-            "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
             "dev": true,
             "dependencies": {
                 "braces": "^3.0.1",
-                "picomatch": "^2.0.5"
+                "picomatch": "^2.2.3"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=8.6"
             }
         },
         "node_modules/mime": {
@@ -3463,9 +3463,9 @@
             "dev": true
         },
         "node_modules/picomatch": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+            "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
             "dev": true,
             "engines": {
                 "node": ">=8.6"
@@ -3550,9 +3550,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.2.9",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
-            "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
+            "version": "8.2.10",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.10.tgz",
+            "integrity": "sha512-b/h7CPV7QEdrqIxtAf2j31U5ef05uBDuvoXv6L51Q4rcS1jdlXAVKJv+atCFdUXYl9dyTHGyoMzIepwowRJjFw==",
             "dev": true,
             "dependencies": {
                 "colorette": "^1.2.2",
@@ -4293,9 +4293,9 @@
             }
         },
         "node_modules/uglify-js": {
-            "version": "3.13.3",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.3.tgz",
-            "integrity": "sha512-otIc7O9LyxpUcQoXzj2hL4LPWKklO6LJWoJUzNa8A17Xgi4fOeDC8FBDOLHnC/Slo1CQgsZMcM6as0M76BZaig==",
+            "version": "3.13.4",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.4.tgz",
+            "integrity": "sha512-kv7fCkIXyQIilD5/yQy8O+uagsYIOt5cZvs890W40/e/rvjMSzJw81o9Bg0tkURxzZBROtDQhW2LFjOGoK3RZw==",
             "optional": true,
             "bin": {
                 "uglifyjs": "bin/uglifyjs"
@@ -4315,9 +4315,9 @@
             }
         },
         "node_modules/underscore": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-            "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.0.tgz",
+            "integrity": "sha512-sCs4H3pCytsb5K7i072FAEC9YlSYFIbosvM0tAKAlpSSUgD7yC1iXSEGdl5XrDKQ1YUB+p/HDzYrSG2H2Vl36g=="
         },
         "node_modules/uniq": {
             "version": "1.0.1",
@@ -4393,9 +4393,9 @@
             "dev": true
         },
         "node_modules/webpack": {
-            "version": "5.30.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.30.0.tgz",
-            "integrity": "sha512-Zr9NIri5yzpfmaMea2lSMV1UygbW0zQsSlGLMgKUm63ACXg6alhd1u4v5UBSBjzYKXJN6BNMGVM7w165e7NxYA==",
+            "version": "5.32.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.32.0.tgz",
+            "integrity": "sha512-jB9PrNMFnPRiZGnm/j3qfNqJmP3ViRzkuQMIf8za0dgOYvSLi/cgA+UEEGvik9EQHX1KYyGng5PgBTTzGrH9xg==",
             "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.0",
@@ -4692,9 +4692,9 @@
             }
         },
         "node_modules/y18n": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.7.tgz",
-            "integrity": "sha512-oOhslryvNcA1lB9WYr+M6TMyLkLg81Dgmyb48ZDU0lvR+5bmNDTMz7iobM1QXooaLhbbrcHrlNaABhI6Vo6StQ==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
             "dev": true,
             "engines": {
                 "node": ">=10"
@@ -4836,15 +4836,15 @@
             "dev": true
         },
         "@firebase/analytics": {
-            "version": "0.6.7",
-            "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.7.tgz",
-            "integrity": "sha512-ObnFDewIqiamvU7UKDx+0jfLrD3LyqEIsXZdjnGQhY/xc10HFH0jp23lOzb39CWf/399X+xMMJ3Uj51VyHwbJQ==",
+            "version": "0.6.9",
+            "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.9.tgz",
+            "integrity": "sha512-G0PkfMq/4tpDXwk/S2LKrXUWiz5tpQ6o2Lf6esgdEcDLpimPl32TrioNkDEDz8Xp0mzpY04UKwvYjT5xuzoKug==",
             "requires": {
                 "@firebase/analytics-types": "0.4.0",
-                "@firebase/component": "0.3.1",
-                "@firebase/installations": "0.4.23",
+                "@firebase/component": "0.4.1",
+                "@firebase/installations": "0.4.25",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.4.1",
+                "@firebase/util": "1.0.0",
                 "tslib": "^2.1.0"
             }
         },
@@ -4854,23 +4854,23 @@
             "integrity": "sha512-Jj2xW+8+8XPfWGkv9HPv/uR+Qrmq37NPYT352wf7MvE9LrstpLVmFg3LqG6MCRr5miLAom5sen2gZ+iOhVDeRA=="
         },
         "@firebase/app": {
-            "version": "0.6.18",
-            "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.18.tgz",
-            "integrity": "sha512-eBThPc4QGHy/FC+oHZsnp4Qk6oksYTZ10B4jXaVH1lCS5eUSKvV1TIzAtpkPzMp2huS/qBz411r1tkQUv5vKcw==",
+            "version": "0.6.20",
+            "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.20.tgz",
+            "integrity": "sha512-5zstJ3Cxw9H5cxfdaAhCH7WHVaRLPhCcgVNwKp6dWeTx2QkIdNvHainX8Vr2RaZchw4MxRjkPfwNVOaq2oFStQ==",
             "requires": {
-                "@firebase/app-types": "0.6.1",
-                "@firebase/component": "0.3.1",
+                "@firebase/app-types": "0.6.2",
+                "@firebase/component": "0.4.1",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.4.1",
+                "@firebase/util": "1.0.0",
                 "dom-storage": "2.1.0",
                 "tslib": "^2.1.0",
                 "xmlhttprequest": "1.8.0"
             }
         },
         "@firebase/app-types": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.1.tgz",
-            "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.2.tgz",
+            "integrity": "sha512-2VXvq/K+n8XMdM4L2xy5bYp2ZXMawJXluUIDzUBvMthVR+lhxK4pfFiqr1mmDbv9ydXvEAuFsD+6DpcZuJcSSw=="
         },
         "@firebase/auth": {
             "version": "0.16.4",
@@ -4878,6 +4878,23 @@
             "integrity": "sha512-zgHPK6/uL6+nAyG9zqammHTF1MQpAN7z/jVRLYkDZS4l81H08b2SzApLbRfW/fmy665xqb5MK7sVH0V1wsiCNw==",
             "requires": {
                 "@firebase/auth-types": "0.10.2"
+            },
+            "dependencies": {
+                "@firebase/auth-types": {
+                    "version": "0.10.2",
+                    "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.2.tgz",
+                    "integrity": "sha512-0GMWVWh5TBCYIQfVerxzDsuvhoFpK0++O9LtP3FWkwYo7EAxp6w0cftAg/8ntU1E5Wg56Ry0b6ti/YGP6g0jlg==",
+                    "requires": {}
+                },
+                "@firebase/util": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.4.1.tgz",
+                    "integrity": "sha512-XhYCOwq4AH+YeQBEnDQvigz50WiiBU4LnJh2+//VMt4J2Ybsk0eTgUHNngUzXsmp80EJrwal3ItODg55q1ajWg==",
+                    "peer": true,
+                    "requires": {
+                        "tslib": "^2.1.0"
+                    }
+                }
             }
         },
         "@firebase/auth-interop-types": {
@@ -4886,52 +4903,46 @@
             "integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw==",
             "requires": {}
         },
-        "@firebase/auth-types": {
-            "version": "0.10.2",
-            "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.2.tgz",
-            "integrity": "sha512-0GMWVWh5TBCYIQfVerxzDsuvhoFpK0++O9LtP3FWkwYo7EAxp6w0cftAg/8ntU1E5Wg56Ry0b6ti/YGP6g0jlg==",
-            "requires": {}
-        },
         "@firebase/component": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.3.1.tgz",
-            "integrity": "sha512-8ACaB772bWwZRE47aVEYzld+jlDPgvHnLZoiVtG6BzygonVnKzwXo0wK6wcRzCbx4kun7G/gXYM0gUMkqvKtRA==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.4.1.tgz",
+            "integrity": "sha512-f0IbIsoe33QzOj554rmDL04PyeZX/nNZYOAwlTzKmHq/JoFN6YoySi+0ZLyCtFrnRgw6zNnR/POXKOdfljWqZA==",
             "requires": {
-                "@firebase/util": "0.4.1",
+                "@firebase/util": "1.0.0",
                 "tslib": "^2.1.0"
             }
         },
         "@firebase/database": {
-            "version": "0.9.7",
-            "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.9.7.tgz",
-            "integrity": "sha512-JUm6CnUxFRuyWvzTAzv/Mo/KYwLtUezpNGa4AzbhbdS8t3ewprc/7ARFErpv95cIM5MgiiPcLOC5F+mLDmrQwA==",
+            "version": "0.9.10",
+            "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.9.10.tgz",
+            "integrity": "sha512-QvKhWpsBK4T1L4iGOpTBRvw4s2nqEtD6qja+L116BejFFJZik+U+cVe3xLKoeyGy2YtbcS28ly0h285pmnYwRw==",
             "requires": {
                 "@firebase/auth-interop-types": "0.1.5",
-                "@firebase/component": "0.3.1",
-                "@firebase/database-types": "0.7.0",
+                "@firebase/component": "0.4.1",
+                "@firebase/database-types": "0.7.2",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.4.1",
+                "@firebase/util": "1.0.0",
                 "faye-websocket": "0.11.3",
                 "tslib": "^2.1.0"
             }
         },
         "@firebase/database-types": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.0.tgz",
-            "integrity": "sha512-FduQmPpUUOHgbOt7/vWlC1ntSLMEqqYessdQ/ODd7RFWm53iVa0T1mpIDtNwqd8gW3k7cajjSjcLjfQGtvLGDg==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.2.tgz",
+            "integrity": "sha512-cdAd/dgwvC0r3oLEDUR+ULs1vBsEvy0b27nlzKhU6LQgm9fCDzgaH9nFGv8x+S9dly4B0egAXkONkVoWcOAisg==",
             "requires": {
-                "@firebase/app-types": "0.6.1"
+                "@firebase/app-types": "0.6.2"
             }
         },
         "@firebase/firestore": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.2.2.tgz",
-            "integrity": "sha512-tFB0gRZcYQ8y9WBO5cSCij8pspF4vv2NdUkG8qWKG9cx2ccXnjo3qiQWRkoLuJGPaicCOGt11c08KvNSy/zfDA==",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.2.4.tgz",
+            "integrity": "sha512-0B4WNVYDusxURRclHHjw/OBLad7gerr25QGljQ0kkpeFEd6bYyoTUeGtP6YlYYog8KhxsR9R5f0NacuzQPS4OA==",
             "requires": {
-                "@firebase/component": "0.3.1",
+                "@firebase/component": "0.4.1",
                 "@firebase/firestore-types": "2.2.0",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.4.1",
+                "@firebase/util": "1.0.0",
                 "@firebase/webchannel-wrapper": "0.4.1",
                 "@grpc/grpc-js": "^1.0.0",
                 "@grpc/proto-loader": "^0.5.0",
@@ -4946,11 +4957,11 @@
             "requires": {}
         },
         "@firebase/functions": {
-            "version": "0.6.5",
-            "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.5.tgz",
-            "integrity": "sha512-8T/BKscHJhzQ7cM9Kn2Hcs8mkA1Zypzvo4b0mue7hRm6W/vzDMsgTiAUk7j7H1HEEf1Saw58h2tlQBg2rdDHPQ==",
+            "version": "0.6.7",
+            "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.7.tgz",
+            "integrity": "sha512-IDw2ww28Tj8t947ySVO9wHghlwNl4bIUo5tPUzAbipfgLlj3GeHwqhvSv++O/ILBu4Rk7KD7cbxtw/rziATHNA==",
             "requires": {
-                "@firebase/component": "0.3.1",
+                "@firebase/component": "0.4.1",
                 "@firebase/functions-types": "0.4.0",
                 "@firebase/messaging-types": "0.5.0",
                 "node-fetch": "2.6.1",
@@ -4963,13 +4974,13 @@
             "integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ=="
         },
         "@firebase/installations": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.23.tgz",
-            "integrity": "sha512-vULPhK0DbDcXL0utJ8Td8+x5ArpUjSbCarz5ttR+u3Xsn1sEC6EX2Tlmua6csqNnBU/VpMo1bopWOvCVyX9jYA==",
+            "version": "0.4.25",
+            "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.25.tgz",
+            "integrity": "sha512-szQ2bpI5NHTRuZAqXNZLq7bkZ1iTURPmojj7xWjBRxyMnDd6lLQ/Ht8Wut0ESH7uzbFNqmZ9oBMh2U9fpBIniA==",
             "requires": {
-                "@firebase/component": "0.3.1",
+                "@firebase/component": "0.4.1",
                 "@firebase/installations-types": "0.3.4",
-                "@firebase/util": "0.4.1",
+                "@firebase/util": "1.0.0",
                 "idb": "3.0.2",
                 "tslib": "^2.1.0"
             }
@@ -4986,14 +4997,14 @@
             "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw=="
         },
         "@firebase/messaging": {
-            "version": "0.7.7",
-            "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.7.tgz",
-            "integrity": "sha512-osS61riot7Kg3YPuQWGqxOHos+IXOrTvTdchFOU/HVxenwmXteOpepEeNC3PZvudnYSKoI/w6voo5+E5yUyftw==",
+            "version": "0.7.9",
+            "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.9.tgz",
+            "integrity": "sha512-zzEmtpBdauT0n0JA5eN/dHeQZkQj/bbfl7CNmhA0EpKU2wTRFZCJYAOZkZEw8OD9/D/aDRcEk3Qq+5I1XcugZA==",
             "requires": {
-                "@firebase/component": "0.3.1",
-                "@firebase/installations": "0.4.23",
+                "@firebase/component": "0.4.1",
+                "@firebase/installations": "0.4.25",
                 "@firebase/messaging-types": "0.5.0",
-                "@firebase/util": "0.4.1",
+                "@firebase/util": "1.0.0",
                 "idb": "3.0.2",
                 "tslib": "^2.1.0"
             }
@@ -5005,15 +5016,15 @@
             "requires": {}
         },
         "@firebase/performance": {
-            "version": "0.4.9",
-            "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.9.tgz",
-            "integrity": "sha512-2BozmCAbvL4iFZwHE+9xSrdl3sJeF1/l8X2Ci4n8n+vwZjQbhq5pHPSZXLVT78i23V3XM14eS4SUJVqNL/QkRw==",
+            "version": "0.4.11",
+            "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.11.tgz",
+            "integrity": "sha512-SQb9QpAkgpPS1QnRLxNAXFTCrW/VT9MidVcJVHuBrCCW9sYY+QVuuWYpaGR4zQDsTx2e/UGUXJgw+z0vaQ0Q6w==",
             "requires": {
-                "@firebase/component": "0.3.1",
-                "@firebase/installations": "0.4.23",
+                "@firebase/component": "0.4.1",
+                "@firebase/installations": "0.4.25",
                 "@firebase/logger": "0.2.6",
                 "@firebase/performance-types": "0.0.13",
-                "@firebase/util": "0.4.1",
+                "@firebase/util": "1.0.0",
                 "tslib": "^2.1.0"
             }
         },
@@ -5033,15 +5044,15 @@
             }
         },
         "@firebase/remote-config": {
-            "version": "0.1.34",
-            "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.34.tgz",
-            "integrity": "sha512-4dXdRjwuTH8lckmF8bPYCq0P/fM3NLV9QAF98Anft7f/0ZZNAucyQpvlK8KP7IRBZcllXq1Rla4THCNFtrLLOA==",
+            "version": "0.1.36",
+            "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.36.tgz",
+            "integrity": "sha512-aQXaBDkEzFix3ycjPiP+4OPSXZmUbFunOiVi20XS9kRZrZfNhCH3HdBYwL1Nl9/AvcOnlZfX+lqa2LuHVXmuwA==",
             "requires": {
-                "@firebase/component": "0.3.1",
-                "@firebase/installations": "0.4.23",
+                "@firebase/component": "0.4.1",
+                "@firebase/installations": "0.4.25",
                 "@firebase/logger": "0.2.6",
                 "@firebase/remote-config-types": "0.1.9",
-                "@firebase/util": "0.4.1",
+                "@firebase/util": "1.0.0",
                 "tslib": "^2.1.0"
             }
         },
@@ -5051,26 +5062,26 @@
             "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA=="
         },
         "@firebase/storage": {
-            "version": "0.4.6",
-            "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.6.tgz",
-            "integrity": "sha512-nXhLuPKGJlty2whW56T5/Kpr/3O+cKSB5YcCcRKUO8eBu/1VvIswPgipWFaIpgZ3hkXJqaNzYLYpTdIf1UPWrQ==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.5.0.tgz",
+            "integrity": "sha512-nwIDikLEVzamuheZSRQbUbmMDITkPclCIokHR+4YbZsNNf7ukVN6PB8V/C8KMTjpDjSn9BOZbd9jF2U1VIgYqQ==",
             "requires": {
-                "@firebase/component": "0.3.1",
-                "@firebase/storage-types": "0.3.13",
-                "@firebase/util": "0.4.1",
+                "@firebase/component": "0.4.1",
+                "@firebase/storage-types": "0.4.0",
+                "@firebase/util": "1.0.0",
                 "tslib": "^2.1.0"
             }
         },
         "@firebase/storage-types": {
-            "version": "0.3.13",
-            "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.13.tgz",
-            "integrity": "sha512-pL7b8d5kMNCCL0w9hF7pr16POyKkb3imOW7w0qYrhBnbyJTdVxMWZhb0HxCFyQWC0w3EiIFFmxoz8NTFZDEFog==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.4.0.tgz",
+            "integrity": "sha512-2xgiLGfDv6Fz5qRrsO47/7PfbV9P+5tEuvEktJYTNxrgTxGPj3sMb7ZkycIb4JE98fAbmGEeMQaRSorqR5bEIQ==",
             "requires": {}
         },
         "@firebase/util": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.4.1.tgz",
-            "integrity": "sha512-XhYCOwq4AH+YeQBEnDQvigz50WiiBU4LnJh2+//VMt4J2Ybsk0eTgUHNngUzXsmp80EJrwal3ItODg55q1ajWg==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.0.0.tgz",
+            "integrity": "sha512-KIEyuyrYKKtit+lAl66c2GVvooM1Pb+Yw/9yuSga1HKYMxNZwSsIMXU8X97sLZf7WJaanV1XNJEMkZTw3xKEoA==",
             "requires": {
                 "tslib": "^2.1.0"
             }
@@ -5187,9 +5198,9 @@
             "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
         },
         "@types/eslint": {
-            "version": "7.2.8",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.8.tgz",
-            "integrity": "sha512-RTKvBsfz0T8CKOGZMfuluDNyMFHnu5lvNr4hWEsQeHXH6FcmIDIozOyWMh36nLGMwVd5UFNXC2xztA8lln22MQ==",
+            "version": "7.2.9",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.9.tgz",
+            "integrity": "sha512-SdAAXZNvWfhtf3X3y1cbbCZhP3xyPh7mfTvzV6CgfWc/ZhiHpyr9bVroe2/RCHIf7gczaNcprhaBLsx0CCJHQA==",
             "dev": true,
             "requires": {
                 "@types/estree": "*",
@@ -5434,9 +5445,9 @@
             }
         },
         "acorn": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
-            "integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.1.tgz",
+            "integrity": "sha512-xYiIVjNuqtKXMxlRMDc6mZUhXehod4a3gbZ1qRlM7icK4EbxUFNLhWoPblCvFtB2Y9CIqHP3CF/rdxLItaQv8g==",
             "dev": true
         },
         "agent-base": {
@@ -5738,16 +5749,16 @@
             "dev": true
         },
         "browserslist": {
-            "version": "4.16.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-            "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+            "version": "4.16.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz",
+            "integrity": "sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001181",
-                "colorette": "^1.2.1",
-                "electron-to-chromium": "^1.3.649",
+                "caniuse-lite": "^1.0.30001208",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.712",
                 "escalade": "^3.1.1",
-                "node-releases": "^1.1.70"
+                "node-releases": "^1.1.71"
             }
         },
         "buffer": {
@@ -5784,9 +5795,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001207",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz",
-            "integrity": "sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw==",
+            "version": "1.0.30001208",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
+            "integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==",
             "dev": true
         },
         "chai": {
@@ -5853,21 +5864,10 @@
             "dev": true
         },
         "chrome-trace-event": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
-            "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.9.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "dev": true
-                }
-            }
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+            "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+            "dev": true
         },
         "cli": {
             "version": "1.0.1",
@@ -6047,9 +6047,9 @@
             }
         },
         "css-loader": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.0.tgz",
-            "integrity": "sha512-MfRo2MjEeLXMlUkeUwN71Vx5oc6EJnx5UQ4Yi9iUtYQvrPtwLUucYptz0hc6n++kdNcyF5olYBS4vPjJDAcLkw==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.1.tgz",
+            "integrity": "sha512-YCyRzlt/jgG1xanXZDG/DHqAueOtXFHeusP9TS478oP1J++JSKOyEgGW1GHVoCj/rkS+GWOlBwqQJBr9yajQ9w==",
             "dev": true,
             "requires": {
                 "camelcase": "^6.2.0",
@@ -6122,9 +6122,9 @@
             }
         },
         "dom-serializer": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
-            "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
+            "integrity": "sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==",
             "requires": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^4.0.0",
@@ -6150,9 +6150,9 @@
             }
         },
         "domutils": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.1.tgz",
-            "integrity": "sha512-hO1XwHMGAthA/1KL7c83oip/6UWo3FlUNIuWiWKltoiQ5oCOiqths8KknvY2jpOohUoUgnwa/+Rm7UpwpSbY/Q==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.2.tgz",
+            "integrity": "sha512-MHTthCb1zj8f1GVfRpeZUbohQf/HdBos0oX5gZcQFepOZPLLRyj6Wn7XS7EMnY7CVpwv8863u2vyE83Hfu28HQ==",
             "requires": {
                 "dom-serializer": "^1.0.1",
                 "domelementtype": "^2.2.0",
@@ -6168,9 +6168,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.709",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.709.tgz",
-            "integrity": "sha512-LolItk2/ikSGQ7SN8UkuKVNMBZp3RG7Itgaxj1npsHRzQobj9JjMneZOZfLhtwlYBe5fCJ75k+cVCiDFUs23oA==",
+            "version": "1.3.713",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.713.tgz",
+            "integrity": "sha512-HWgkyX4xTHmxcWWlvv7a87RHSINEcpKYZmDMxkUlHcY+CJcfx7xEfBHuXVsO1rzyYs1WQJ7EgDp2CoErakBIow==",
             "dev": true
         },
         "emoji-regex": {
@@ -6439,24 +6439,24 @@
             }
         },
         "firebase": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.3.2.tgz",
-            "integrity": "sha512-qGKASp6lXcV8NriHz/3wdltyLUjHOVkON6TQ1syGjW0sS5q/yTl9LK4O83hDLwG+UeRVRhLOaVa3jaLG4o3gnw==",
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.4.1.tgz",
+            "integrity": "sha512-PMDt9iU8ry5P7PSrGQ+72O1gkfa5rNAeybMZhP22nKOh40sVozSkcKGZAFumXog7tjlslHJhUEZgfZbKCNkC8Q==",
             "requires": {
-                "@firebase/analytics": "0.6.7",
-                "@firebase/app": "0.6.18",
-                "@firebase/app-types": "0.6.1",
+                "@firebase/analytics": "0.6.9",
+                "@firebase/app": "0.6.20",
+                "@firebase/app-types": "0.6.2",
                 "@firebase/auth": "0.16.4",
-                "@firebase/database": "0.9.7",
-                "@firebase/firestore": "2.2.2",
-                "@firebase/functions": "0.6.5",
-                "@firebase/installations": "0.4.23",
-                "@firebase/messaging": "0.7.7",
-                "@firebase/performance": "0.4.9",
+                "@firebase/database": "0.9.10",
+                "@firebase/firestore": "2.2.4",
+                "@firebase/functions": "0.6.7",
+                "@firebase/installations": "0.4.25",
+                "@firebase/messaging": "0.7.9",
+                "@firebase/performance": "0.4.11",
                 "@firebase/polyfill": "0.3.36",
-                "@firebase/remote-config": "0.1.34",
-                "@firebase/storage": "0.4.6",
-                "@firebase/util": "0.4.1"
+                "@firebase/remote-config": "0.1.36",
+                "@firebase/storage": "0.5.0",
+                "@firebase/util": "1.0.0"
             }
         },
         "flat": {
@@ -6670,13 +6670,13 @@
             }
         },
         "htmlparser2": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.0.1.tgz",
-            "integrity": "sha512-GDKPd+vk4jvSuvCbyuzx/unmXkk090Azec7LovXP8as1Hn8q9p3hbjmDGbUqqhknw0ajwit6LiiWqfiTUPMK7w==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+            "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
             "requires": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^4.0.0",
-                "domutils": "^2.4.4",
+                "domutils": "^2.5.2",
                 "entities": "^2.0.0"
             }
         },
@@ -7194,13 +7194,13 @@
             "dev": true
         },
         "micromatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-            "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
             "dev": true,
             "requires": {
                 "braces": "^3.0.1",
-                "picomatch": "^2.0.5"
+                "picomatch": "^2.2.3"
             }
         },
         "mime": {
@@ -7484,9 +7484,9 @@
             "dev": true
         },
         "picomatch": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+            "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
             "dev": true
         },
         "pkg-dir": {
@@ -7544,9 +7544,9 @@
             "peer": true
         },
         "postcss": {
-            "version": "8.2.9",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
-            "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
+            "version": "8.2.10",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.10.tgz",
+            "integrity": "sha512-b/h7CPV7QEdrqIxtAf2j31U5ef05uBDuvoXv6L51Q4rcS1jdlXAVKJv+atCFdUXYl9dyTHGyoMzIepwowRJjFw==",
             "dev": true,
             "requires": {
                 "colorette": "^1.2.2",
@@ -8070,9 +8070,9 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.13.3",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.3.tgz",
-            "integrity": "sha512-otIc7O9LyxpUcQoXzj2hL4LPWKklO6LJWoJUzNa8A17Xgi4fOeDC8FBDOLHnC/Slo1CQgsZMcM6as0M76BZaig==",
+            "version": "3.13.4",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.4.tgz",
+            "integrity": "sha512-kv7fCkIXyQIilD5/yQy8O+uagsYIOt5cZvs890W40/e/rvjMSzJw81o9Bg0tkURxzZBROtDQhW2LFjOGoK3RZw==",
             "optional": true
         },
         "unbzip2-stream": {
@@ -8086,9 +8086,9 @@
             }
         },
         "underscore": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-            "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.0.tgz",
+            "integrity": "sha512-sCs4H3pCytsb5K7i072FAEC9YlSYFIbosvM0tAKAlpSSUgD7yC1iXSEGdl5XrDKQ1YUB+p/HDzYrSG2H2Vl36g=="
         },
         "uniq": {
             "version": "1.0.1",
@@ -8145,9 +8145,9 @@
             "dev": true
         },
         "webpack": {
-            "version": "5.30.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.30.0.tgz",
-            "integrity": "sha512-Zr9NIri5yzpfmaMea2lSMV1UygbW0zQsSlGLMgKUm63ACXg6alhd1u4v5UBSBjzYKXJN6BNMGVM7w165e7NxYA==",
+            "version": "5.32.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.32.0.tgz",
+            "integrity": "sha512-jB9PrNMFnPRiZGnm/j3qfNqJmP3ViRzkuQMIf8za0dgOYvSLi/cgA+UEEGvik9EQHX1KYyGng5PgBTTzGrH9xg==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.0",
@@ -8356,9 +8356,9 @@
             "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
         },
         "y18n": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.7.tgz",
-            "integrity": "sha512-oOhslryvNcA1lB9WYr+M6TMyLkLg81Dgmyb48ZDU0lvR+5bmNDTMz7iobM1QXooaLhbbrcHrlNaABhI6Vo6StQ==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
             "dev": true
         },
         "yallist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,15 +47,15 @@
             }
         },
         "node_modules/@firebase/analytics": {
-            "version": "0.6.6",
-            "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.6.tgz",
-            "integrity": "sha512-bf1Kvfigce1dwAQz3iHEKHyz2Kps42ikpTiPBpvMoLaP2+45H5Vmkm33T6w/yjyOPmhKvJtGDMRPrL+BozhWxQ==",
+            "version": "0.6.7",
+            "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.7.tgz",
+            "integrity": "sha512-ObnFDewIqiamvU7UKDx+0jfLrD3LyqEIsXZdjnGQhY/xc10HFH0jp23lOzb39CWf/399X+xMMJ3Uj51VyHwbJQ==",
             "dependencies": {
                 "@firebase/analytics-types": "0.4.0",
-                "@firebase/component": "0.3.0",
-                "@firebase/installations": "0.4.22",
+                "@firebase/component": "0.3.1",
+                "@firebase/installations": "0.4.23",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
@@ -69,14 +69,14 @@
             "integrity": "sha512-Jj2xW+8+8XPfWGkv9HPv/uR+Qrmq37NPYT352wf7MvE9LrstpLVmFg3LqG6MCRr5miLAom5sen2gZ+iOhVDeRA=="
         },
         "node_modules/@firebase/app": {
-            "version": "0.6.17",
-            "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.17.tgz",
-            "integrity": "sha512-xLXY8507VaVkg5l1mWIUh/OrGqutexKxngbvEdpD9PXY2qiBRApXgvdIJ+DuuhaZDnG+3M/5hlP1IIx7XnkAsA==",
+            "version": "0.6.18",
+            "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.18.tgz",
+            "integrity": "sha512-eBThPc4QGHy/FC+oHZsnp4Qk6oksYTZ10B4jXaVH1lCS5eUSKvV1TIzAtpkPzMp2huS/qBz411r1tkQUv5vKcw==",
             "dependencies": {
                 "@firebase/app-types": "0.6.1",
-                "@firebase/component": "0.3.0",
+                "@firebase/component": "0.3.1",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "dom-storage": "2.1.0",
                 "tslib": "^2.1.0",
                 "xmlhttprequest": "1.8.0"
@@ -117,24 +117,24 @@
             }
         },
         "node_modules/@firebase/component": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.3.0.tgz",
-            "integrity": "sha512-jlyaQMLKkzetjHd41P6wywNNVIy+Pqa2Xf+GS/cdgLyPD5IhjqvJHEv0SrLL2ceRhXCA5ETUxSvV6aKbFgV3Vw==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.3.1.tgz",
+            "integrity": "sha512-8ACaB772bWwZRE47aVEYzld+jlDPgvHnLZoiVtG6BzygonVnKzwXo0wK6wcRzCbx4kun7G/gXYM0gUMkqvKtRA==",
             "dependencies": {
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "tslib": "^2.1.0"
             }
         },
         "node_modules/@firebase/database": {
-            "version": "0.9.6",
-            "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.9.6.tgz",
-            "integrity": "sha512-8vuErwj6AlfFt0Y4q1aJYmFDcymV+Rd6Mik0XdgZ+a4iel+kGxGN3izxCQ/hWZNIvd2lCC3XI2bsRoDEkS4Nnw==",
+            "version": "0.9.7",
+            "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.9.7.tgz",
+            "integrity": "sha512-JUm6CnUxFRuyWvzTAzv/Mo/KYwLtUezpNGa4AzbhbdS8t3ewprc/7ARFErpv95cIM5MgiiPcLOC5F+mLDmrQwA==",
             "dependencies": {
                 "@firebase/auth-interop-types": "0.1.5",
-                "@firebase/component": "0.3.0",
+                "@firebase/component": "0.3.1",
                 "@firebase/database-types": "0.7.0",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "faye-websocket": "0.11.3",
                 "tslib": "^2.1.0"
             }
@@ -148,14 +148,14 @@
             }
         },
         "node_modules/@firebase/firestore": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.2.1.tgz",
-            "integrity": "sha512-3NNzYk517usr0g0FL+RiUVVexsiNtduktv0t+xLApqmCue/MUodv5r0tYcCeo733Yq7+SSFsLgNd//jqa0zLOg==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.2.2.tgz",
+            "integrity": "sha512-tFB0gRZcYQ8y9WBO5cSCij8pspF4vv2NdUkG8qWKG9cx2ccXnjo3qiQWRkoLuJGPaicCOGt11c08KvNSy/zfDA==",
             "dependencies": {
-                "@firebase/component": "0.3.0",
+                "@firebase/component": "0.3.1",
                 "@firebase/firestore-types": "2.2.0",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "@firebase/webchannel-wrapper": "0.4.1",
                 "@grpc/grpc-js": "^1.0.0",
                 "@grpc/proto-loader": "^0.5.0",
@@ -179,11 +179,11 @@
             }
         },
         "node_modules/@firebase/functions": {
-            "version": "0.6.4",
-            "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.4.tgz",
-            "integrity": "sha512-5OK5vTfpM7JDadCrad/c1xLND0RGulZY9URL6fyoAYzMOx1Y6FWSM77LEjPfCQsd60P1qSJBTJ+9tzVMbaylWw==",
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.5.tgz",
+            "integrity": "sha512-8T/BKscHJhzQ7cM9Kn2Hcs8mkA1Zypzvo4b0mue7hRm6W/vzDMsgTiAUk7j7H1HEEf1Saw58h2tlQBg2rdDHPQ==",
             "dependencies": {
-                "@firebase/component": "0.3.0",
+                "@firebase/component": "0.3.1",
                 "@firebase/functions-types": "0.4.0",
                 "@firebase/messaging-types": "0.5.0",
                 "node-fetch": "2.6.1",
@@ -200,13 +200,13 @@
             "integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ=="
         },
         "node_modules/@firebase/installations": {
-            "version": "0.4.22",
-            "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.22.tgz",
-            "integrity": "sha512-ICsNUiA0iX9b/kgJP2h9RAkGI+3aAfeRDLcAIoVBwIEZkNfxXTzXnrde04mnsGkA4zh74ADJCotzUuKb9QjIZg==",
+            "version": "0.4.23",
+            "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.23.tgz",
+            "integrity": "sha512-vULPhK0DbDcXL0utJ8Td8+x5ArpUjSbCarz5ttR+u3Xsn1sEC6EX2Tlmua6csqNnBU/VpMo1bopWOvCVyX9jYA==",
             "dependencies": {
-                "@firebase/component": "0.3.0",
+                "@firebase/component": "0.3.1",
                 "@firebase/installations-types": "0.3.4",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "idb": "3.0.2",
                 "tslib": "^2.1.0"
             },
@@ -229,14 +229,14 @@
             "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw=="
         },
         "node_modules/@firebase/messaging": {
-            "version": "0.7.6",
-            "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.6.tgz",
-            "integrity": "sha512-kjzIiEunzWtkFzpyXfwHdQwWG1jLnAziKd8nIrBsGGW/dNV1VVUWB1iBnhGvnY0qrRcmqx0SMY6DtYIQasR5Eg==",
+            "version": "0.7.7",
+            "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.7.tgz",
+            "integrity": "sha512-osS61riot7Kg3YPuQWGqxOHos+IXOrTvTdchFOU/HVxenwmXteOpepEeNC3PZvudnYSKoI/w6voo5+E5yUyftw==",
             "dependencies": {
-                "@firebase/component": "0.3.0",
-                "@firebase/installations": "0.4.22",
+                "@firebase/component": "0.3.1",
+                "@firebase/installations": "0.4.23",
                 "@firebase/messaging-types": "0.5.0",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "idb": "3.0.2",
                 "tslib": "^2.1.0"
             },
@@ -254,15 +254,15 @@
             }
         },
         "node_modules/@firebase/performance": {
-            "version": "0.4.8",
-            "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.8.tgz",
-            "integrity": "sha512-0YG37wfe0RxVKSrNUUVKCMYXU7fGCp+pxxlU5ri4fLcsHqFMShEVYS9U4ahe7gg9a/ah5qSp+kHomGquNt8IIw==",
+            "version": "0.4.9",
+            "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.9.tgz",
+            "integrity": "sha512-2BozmCAbvL4iFZwHE+9xSrdl3sJeF1/l8X2Ci4n8n+vwZjQbhq5pHPSZXLVT78i23V3XM14eS4SUJVqNL/QkRw==",
             "dependencies": {
-                "@firebase/component": "0.3.0",
-                "@firebase/installations": "0.4.22",
+                "@firebase/component": "0.3.1",
+                "@firebase/installations": "0.4.23",
                 "@firebase/logger": "0.2.6",
                 "@firebase/performance-types": "0.0.13",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
@@ -286,15 +286,15 @@
             }
         },
         "node_modules/@firebase/remote-config": {
-            "version": "0.1.33",
-            "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.33.tgz",
-            "integrity": "sha512-bBCC0UOYioIyJXlQGBHbDcZo7NTVEcgQGoqRpenSNZ1obsjTt0SXJMcYJFiP+wzut8O3UBKlc2q72UgX8naPHA==",
+            "version": "0.1.34",
+            "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.34.tgz",
+            "integrity": "sha512-4dXdRjwuTH8lckmF8bPYCq0P/fM3NLV9QAF98Anft7f/0ZZNAucyQpvlK8KP7IRBZcllXq1Rla4THCNFtrLLOA==",
             "dependencies": {
-                "@firebase/component": "0.3.0",
-                "@firebase/installations": "0.4.22",
+                "@firebase/component": "0.3.1",
+                "@firebase/installations": "0.4.23",
                 "@firebase/logger": "0.2.6",
                 "@firebase/remote-config-types": "0.1.9",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
@@ -308,13 +308,13 @@
             "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA=="
         },
         "node_modules/@firebase/storage": {
-            "version": "0.4.5",
-            "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.5.tgz",
-            "integrity": "sha512-ZSuK7iqHMI7SJV55BmqtAFwdZC3CQ5SudkAQk7cBHEqZZUx0HGnalOqLu04zPlJsQRIT/CgekaizXpHuUPKfyw==",
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.6.tgz",
+            "integrity": "sha512-nXhLuPKGJlty2whW56T5/Kpr/3O+cKSB5YcCcRKUO8eBu/1VvIswPgipWFaIpgZ3hkXJqaNzYLYpTdIf1UPWrQ==",
             "dependencies": {
-                "@firebase/component": "0.3.0",
+                "@firebase/component": "0.3.1",
                 "@firebase/storage-types": "0.3.13",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
@@ -332,11 +332,11 @@
             }
         },
         "node_modules/@firebase/util": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.4.0.tgz",
-            "integrity": "sha512-z8A+9YGM61ZXQ2KBSVwxXaELOJjG+EQ374YolqNVMvWBJzTNGZGaVP81Ggl8XD10Xinyt1Dgdo86JDV0OAnvqA==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.4.1.tgz",
+            "integrity": "sha512-XhYCOwq4AH+YeQBEnDQvigz50WiiBU4LnJh2+//VMt4J2Ybsk0eTgUHNngUzXsmp80EJrwal3ItODg55q1ajWg==",
             "dependencies": {
-                "tslib": "^2.0.0"
+                "tslib": "^2.1.0"
             }
         },
         "node_modules/@firebase/webchannel-wrapper": {
@@ -467,9 +467,9 @@
             "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
         },
         "node_modules/@types/eslint": {
-            "version": "7.2.7",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.7.tgz",
-            "integrity": "sha512-EHXbc1z2GoQRqHaAT7+grxlTJ3WE2YNeD6jlpPoRc83cCoThRY+NUWjCUZaYmk51OICkPXn2hhphcWcWXgNW0Q==",
+            "version": "7.2.8",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.8.tgz",
+            "integrity": "sha512-RTKvBsfz0T8CKOGZMfuluDNyMFHnu5lvNr4hWEsQeHXH6FcmIDIozOyWMh36nLGMwVd5UFNXC2xztA8lln22MQ==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -811,9 +811,9 @@
             }
         },
         "node_modules/anymatch": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-            "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+            "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
             "dev": true,
             "dependencies": {
                 "normalize-path": "^3.0.0",
@@ -1026,9 +1026,9 @@
             "dev": true
         },
         "node_modules/balanced-match": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
         "node_modules/base64-js": {
@@ -1208,9 +1208,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001204",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz",
-            "integrity": "sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ==",
+            "version": "1.0.30001207",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz",
+            "integrity": "sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw==",
             "dev": true
         },
         "node_modules/chai": {
@@ -1455,9 +1455,9 @@
             }
         },
         "node_modules/copy-webpack-plugin": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-8.1.0.tgz",
-            "integrity": "sha512-Soiq8kXI2AZkpw3dSp18u6oU2JonC7UKv3UdXsKOmT1A5QT46ku9+6c0Qy29JDbSavQJNN1/eKGpd3QNw+cZWg==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-8.1.1.tgz",
+            "integrity": "sha512-rYM2uzRxrLRpcyPqGceRBDpxxUV8vcDqIKxAUKfcnFpcrPxT5+XvhTxv7XLjo5AvEJFPdAE3zCogG2JVahqgSQ==",
             "dev": true,
             "dependencies": {
                 "fast-glob": "^3.2.5",
@@ -1677,9 +1677,9 @@
             }
         },
         "node_modules/domelementtype": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-            "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+            "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
             "funding": [
                 {
                     "type": "github",
@@ -1688,11 +1688,11 @@
             ]
         },
         "node_modules/domhandler": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-            "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.1.0.tgz",
+            "integrity": "sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==",
             "dependencies": {
-                "domelementtype": "^2.1.0"
+                "domelementtype": "^2.2.0"
             },
             "engines": {
                 "node": ">= 4"
@@ -1702,13 +1702,13 @@
             }
         },
         "node_modules/domutils": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.0.tgz",
-            "integrity": "sha512-Ho16rzNMOFk2fPwChGh3D2D9OEHAfG19HgmRR2l+WLSsIstNsAYBzePH412bL0y5T44ejABIVfTHQ8nqi/tBCg==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.1.tgz",
+            "integrity": "sha512-hO1XwHMGAthA/1KL7c83oip/6UWo3FlUNIuWiWKltoiQ5oCOiqths8KknvY2jpOohUoUgnwa/+Rm7UpwpSbY/Q==",
             "dependencies": {
                 "dom-serializer": "^1.0.1",
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.0.0"
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.1.0"
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
@@ -1723,9 +1723,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.3.702",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.702.tgz",
-            "integrity": "sha512-qJVUKFWQnF6wP7MmTngDkmm8/KPzaiTXNFOAg5j7DSa6J7kPou7mTBqC8jpUOxauQWwHR3pn4dMRdV8IE1xdtA==",
+            "version": "1.3.709",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.709.tgz",
+            "integrity": "sha512-LolItk2/ikSGQ7SN8UkuKVNMBZp3RG7Itgaxj1npsHRzQobj9JjMneZOZfLhtwlYBe5fCJ75k+cVCiDFUs23oA==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -1786,9 +1786,9 @@
             }
         },
         "node_modules/envinfo": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.4.tgz",
-            "integrity": "sha512-TQXTYFVVwwluWSFis6K2XKxgrD22jEv0FTuLCQI+OjH7rn93+iY0fSSFM5lrSxFY+H1+B0/cvvlamr3UsBivdQ==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
+            "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
             "dev": true,
             "bin": {
                 "envinfo": "dist/cli.js"
@@ -2089,24 +2089,24 @@
             }
         },
         "node_modules/firebase": {
-            "version": "8.3.1",
-            "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.3.1.tgz",
-            "integrity": "sha512-2BhzHQ8ZDh4BLZ9bicW8FEKFOYmu/w1sKhR5vi4X9SP+dsYNoKyFOP7Sfmk0GoENzt2+Y04GgfS5YERXLQky+w==",
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.3.2.tgz",
+            "integrity": "sha512-qGKASp6lXcV8NriHz/3wdltyLUjHOVkON6TQ1syGjW0sS5q/yTl9LK4O83hDLwG+UeRVRhLOaVa3jaLG4o3gnw==",
             "dependencies": {
-                "@firebase/analytics": "0.6.6",
-                "@firebase/app": "0.6.17",
+                "@firebase/analytics": "0.6.7",
+                "@firebase/app": "0.6.18",
                 "@firebase/app-types": "0.6.1",
                 "@firebase/auth": "0.16.4",
-                "@firebase/database": "0.9.6",
-                "@firebase/firestore": "2.2.1",
-                "@firebase/functions": "0.6.4",
-                "@firebase/installations": "0.4.22",
-                "@firebase/messaging": "0.7.6",
-                "@firebase/performance": "0.4.8",
+                "@firebase/database": "0.9.7",
+                "@firebase/firestore": "2.2.2",
+                "@firebase/functions": "0.6.5",
+                "@firebase/installations": "0.4.23",
+                "@firebase/messaging": "0.7.7",
+                "@firebase/performance": "0.4.9",
                 "@firebase/polyfill": "0.3.36",
-                "@firebase/remote-config": "0.1.33",
-                "@firebase/storage": "0.4.5",
-                "@firebase/util": "0.4.0"
+                "@firebase/remote-config": "0.1.34",
+                "@firebase/storage": "0.4.6",
+                "@firebase/util": "0.4.1"
             },
             "engines": {
                 "node": "^8.13.0 || >=10.10.0"
@@ -2729,9 +2729,9 @@
             }
         },
         "node_modules/jshint/node_modules/dom-serializer/node_modules/domelementtype": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-            "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+            "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
             "dev": true,
             "funding": [
                 {
@@ -3079,21 +3079,21 @@
             }
         },
         "node_modules/mime-db": {
-            "version": "1.46.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-            "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
+            "version": "1.47.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+            "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/mime-types": {
-            "version": "2.1.29",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
-            "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+            "version": "2.1.30",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+            "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
             "dev": true,
             "dependencies": {
-                "mime-db": "1.46.0"
+                "mime-db": "1.47.0"
             },
             "engines": {
                 "node": ">= 0.6"
@@ -3550,13 +3550,13 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.2.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.8.tgz",
-            "integrity": "sha512-1F0Xb2T21xET7oQV9eKuctbM9S7BC0fetoHCc4H13z0PT6haiRLP4T0ZY4XWh7iLP0usgqykT6p9B2RtOf4FPw==",
+            "version": "8.2.9",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
+            "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
             "dev": true,
             "dependencies": {
                 "colorette": "^1.2.2",
-                "nanoid": "^3.1.20",
+                "nanoid": "^3.1.22",
                 "source-map": "^0.6.1"
             },
             "engines": {
@@ -3646,6 +3646,18 @@
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
             "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
             "dev": true
+        },
+        "node_modules/postcss/node_modules/nanoid": {
+            "version": "3.1.22",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
+            "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
+            "dev": true,
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
         },
         "node_modules/printj": {
             "version": "1.1.2",
@@ -4267,9 +4279,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-            "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+            "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
         },
         "node_modules/type-detect": {
             "version": "4.0.8",
@@ -4381,9 +4393,9 @@
             "dev": true
         },
         "node_modules/webpack": {
-            "version": "5.28.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.28.0.tgz",
-            "integrity": "sha512-1xllYVmA4dIvRjHzwELgW4KjIU1fW4PEuEnjsylz7k7H5HgPOctIq7W1jrt3sKH9yG5d72//XWzsHhfoWvsQVg==",
+            "version": "5.30.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.30.0.tgz",
+            "integrity": "sha512-Zr9NIri5yzpfmaMea2lSMV1UygbW0zQsSlGLMgKUm63ACXg6alhd1u4v5UBSBjzYKXJN6BNMGVM7w165e7NxYA==",
             "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.0",
@@ -4680,9 +4692,9 @@
             }
         },
         "node_modules/y18n": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-            "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.7.tgz",
+            "integrity": "sha512-oOhslryvNcA1lB9WYr+M6TMyLkLg81Dgmyb48ZDU0lvR+5bmNDTMz7iobM1QXooaLhbbrcHrlNaABhI6Vo6StQ==",
             "dev": true,
             "engines": {
                 "node": ">=10"
@@ -4824,15 +4836,15 @@
             "dev": true
         },
         "@firebase/analytics": {
-            "version": "0.6.6",
-            "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.6.tgz",
-            "integrity": "sha512-bf1Kvfigce1dwAQz3iHEKHyz2Kps42ikpTiPBpvMoLaP2+45H5Vmkm33T6w/yjyOPmhKvJtGDMRPrL+BozhWxQ==",
+            "version": "0.6.7",
+            "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.7.tgz",
+            "integrity": "sha512-ObnFDewIqiamvU7UKDx+0jfLrD3LyqEIsXZdjnGQhY/xc10HFH0jp23lOzb39CWf/399X+xMMJ3Uj51VyHwbJQ==",
             "requires": {
                 "@firebase/analytics-types": "0.4.0",
-                "@firebase/component": "0.3.0",
-                "@firebase/installations": "0.4.22",
+                "@firebase/component": "0.3.1",
+                "@firebase/installations": "0.4.23",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "tslib": "^2.1.0"
             }
         },
@@ -4842,14 +4854,14 @@
             "integrity": "sha512-Jj2xW+8+8XPfWGkv9HPv/uR+Qrmq37NPYT352wf7MvE9LrstpLVmFg3LqG6MCRr5miLAom5sen2gZ+iOhVDeRA=="
         },
         "@firebase/app": {
-            "version": "0.6.17",
-            "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.17.tgz",
-            "integrity": "sha512-xLXY8507VaVkg5l1mWIUh/OrGqutexKxngbvEdpD9PXY2qiBRApXgvdIJ+DuuhaZDnG+3M/5hlP1IIx7XnkAsA==",
+            "version": "0.6.18",
+            "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.18.tgz",
+            "integrity": "sha512-eBThPc4QGHy/FC+oHZsnp4Qk6oksYTZ10B4jXaVH1lCS5eUSKvV1TIzAtpkPzMp2huS/qBz411r1tkQUv5vKcw==",
             "requires": {
                 "@firebase/app-types": "0.6.1",
-                "@firebase/component": "0.3.0",
+                "@firebase/component": "0.3.1",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "dom-storage": "2.1.0",
                 "tslib": "^2.1.0",
                 "xmlhttprequest": "1.8.0"
@@ -4881,24 +4893,24 @@
             "requires": {}
         },
         "@firebase/component": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.3.0.tgz",
-            "integrity": "sha512-jlyaQMLKkzetjHd41P6wywNNVIy+Pqa2Xf+GS/cdgLyPD5IhjqvJHEv0SrLL2ceRhXCA5ETUxSvV6aKbFgV3Vw==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.3.1.tgz",
+            "integrity": "sha512-8ACaB772bWwZRE47aVEYzld+jlDPgvHnLZoiVtG6BzygonVnKzwXo0wK6wcRzCbx4kun7G/gXYM0gUMkqvKtRA==",
             "requires": {
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "tslib": "^2.1.0"
             }
         },
         "@firebase/database": {
-            "version": "0.9.6",
-            "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.9.6.tgz",
-            "integrity": "sha512-8vuErwj6AlfFt0Y4q1aJYmFDcymV+Rd6Mik0XdgZ+a4iel+kGxGN3izxCQ/hWZNIvd2lCC3XI2bsRoDEkS4Nnw==",
+            "version": "0.9.7",
+            "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.9.7.tgz",
+            "integrity": "sha512-JUm6CnUxFRuyWvzTAzv/Mo/KYwLtUezpNGa4AzbhbdS8t3ewprc/7ARFErpv95cIM5MgiiPcLOC5F+mLDmrQwA==",
             "requires": {
                 "@firebase/auth-interop-types": "0.1.5",
-                "@firebase/component": "0.3.0",
+                "@firebase/component": "0.3.1",
                 "@firebase/database-types": "0.7.0",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "faye-websocket": "0.11.3",
                 "tslib": "^2.1.0"
             }
@@ -4912,14 +4924,14 @@
             }
         },
         "@firebase/firestore": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.2.1.tgz",
-            "integrity": "sha512-3NNzYk517usr0g0FL+RiUVVexsiNtduktv0t+xLApqmCue/MUodv5r0tYcCeo733Yq7+SSFsLgNd//jqa0zLOg==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.2.2.tgz",
+            "integrity": "sha512-tFB0gRZcYQ8y9WBO5cSCij8pspF4vv2NdUkG8qWKG9cx2ccXnjo3qiQWRkoLuJGPaicCOGt11c08KvNSy/zfDA==",
             "requires": {
-                "@firebase/component": "0.3.0",
+                "@firebase/component": "0.3.1",
                 "@firebase/firestore-types": "2.2.0",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "@firebase/webchannel-wrapper": "0.4.1",
                 "@grpc/grpc-js": "^1.0.0",
                 "@grpc/proto-loader": "^0.5.0",
@@ -4934,11 +4946,11 @@
             "requires": {}
         },
         "@firebase/functions": {
-            "version": "0.6.4",
-            "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.4.tgz",
-            "integrity": "sha512-5OK5vTfpM7JDadCrad/c1xLND0RGulZY9URL6fyoAYzMOx1Y6FWSM77LEjPfCQsd60P1qSJBTJ+9tzVMbaylWw==",
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.5.tgz",
+            "integrity": "sha512-8T/BKscHJhzQ7cM9Kn2Hcs8mkA1Zypzvo4b0mue7hRm6W/vzDMsgTiAUk7j7H1HEEf1Saw58h2tlQBg2rdDHPQ==",
             "requires": {
-                "@firebase/component": "0.3.0",
+                "@firebase/component": "0.3.1",
                 "@firebase/functions-types": "0.4.0",
                 "@firebase/messaging-types": "0.5.0",
                 "node-fetch": "2.6.1",
@@ -4951,13 +4963,13 @@
             "integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ=="
         },
         "@firebase/installations": {
-            "version": "0.4.22",
-            "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.22.tgz",
-            "integrity": "sha512-ICsNUiA0iX9b/kgJP2h9RAkGI+3aAfeRDLcAIoVBwIEZkNfxXTzXnrde04mnsGkA4zh74ADJCotzUuKb9QjIZg==",
+            "version": "0.4.23",
+            "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.23.tgz",
+            "integrity": "sha512-vULPhK0DbDcXL0utJ8Td8+x5ArpUjSbCarz5ttR+u3Xsn1sEC6EX2Tlmua6csqNnBU/VpMo1bopWOvCVyX9jYA==",
             "requires": {
-                "@firebase/component": "0.3.0",
+                "@firebase/component": "0.3.1",
                 "@firebase/installations-types": "0.3.4",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "idb": "3.0.2",
                 "tslib": "^2.1.0"
             }
@@ -4974,14 +4986,14 @@
             "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw=="
         },
         "@firebase/messaging": {
-            "version": "0.7.6",
-            "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.6.tgz",
-            "integrity": "sha512-kjzIiEunzWtkFzpyXfwHdQwWG1jLnAziKd8nIrBsGGW/dNV1VVUWB1iBnhGvnY0qrRcmqx0SMY6DtYIQasR5Eg==",
+            "version": "0.7.7",
+            "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.7.tgz",
+            "integrity": "sha512-osS61riot7Kg3YPuQWGqxOHos+IXOrTvTdchFOU/HVxenwmXteOpepEeNC3PZvudnYSKoI/w6voo5+E5yUyftw==",
             "requires": {
-                "@firebase/component": "0.3.0",
-                "@firebase/installations": "0.4.22",
+                "@firebase/component": "0.3.1",
+                "@firebase/installations": "0.4.23",
                 "@firebase/messaging-types": "0.5.0",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "idb": "3.0.2",
                 "tslib": "^2.1.0"
             }
@@ -4993,15 +5005,15 @@
             "requires": {}
         },
         "@firebase/performance": {
-            "version": "0.4.8",
-            "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.8.tgz",
-            "integrity": "sha512-0YG37wfe0RxVKSrNUUVKCMYXU7fGCp+pxxlU5ri4fLcsHqFMShEVYS9U4ahe7gg9a/ah5qSp+kHomGquNt8IIw==",
+            "version": "0.4.9",
+            "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.9.tgz",
+            "integrity": "sha512-2BozmCAbvL4iFZwHE+9xSrdl3sJeF1/l8X2Ci4n8n+vwZjQbhq5pHPSZXLVT78i23V3XM14eS4SUJVqNL/QkRw==",
             "requires": {
-                "@firebase/component": "0.3.0",
-                "@firebase/installations": "0.4.22",
+                "@firebase/component": "0.3.1",
+                "@firebase/installations": "0.4.23",
                 "@firebase/logger": "0.2.6",
                 "@firebase/performance-types": "0.0.13",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "tslib": "^2.1.0"
             }
         },
@@ -5021,15 +5033,15 @@
             }
         },
         "@firebase/remote-config": {
-            "version": "0.1.33",
-            "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.33.tgz",
-            "integrity": "sha512-bBCC0UOYioIyJXlQGBHbDcZo7NTVEcgQGoqRpenSNZ1obsjTt0SXJMcYJFiP+wzut8O3UBKlc2q72UgX8naPHA==",
+            "version": "0.1.34",
+            "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.34.tgz",
+            "integrity": "sha512-4dXdRjwuTH8lckmF8bPYCq0P/fM3NLV9QAF98Anft7f/0ZZNAucyQpvlK8KP7IRBZcllXq1Rla4THCNFtrLLOA==",
             "requires": {
-                "@firebase/component": "0.3.0",
-                "@firebase/installations": "0.4.22",
+                "@firebase/component": "0.3.1",
+                "@firebase/installations": "0.4.23",
                 "@firebase/logger": "0.2.6",
                 "@firebase/remote-config-types": "0.1.9",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "tslib": "^2.1.0"
             }
         },
@@ -5039,13 +5051,13 @@
             "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA=="
         },
         "@firebase/storage": {
-            "version": "0.4.5",
-            "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.5.tgz",
-            "integrity": "sha512-ZSuK7iqHMI7SJV55BmqtAFwdZC3CQ5SudkAQk7cBHEqZZUx0HGnalOqLu04zPlJsQRIT/CgekaizXpHuUPKfyw==",
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.6.tgz",
+            "integrity": "sha512-nXhLuPKGJlty2whW56T5/Kpr/3O+cKSB5YcCcRKUO8eBu/1VvIswPgipWFaIpgZ3hkXJqaNzYLYpTdIf1UPWrQ==",
             "requires": {
-                "@firebase/component": "0.3.0",
+                "@firebase/component": "0.3.1",
                 "@firebase/storage-types": "0.3.13",
-                "@firebase/util": "0.4.0",
+                "@firebase/util": "0.4.1",
                 "tslib": "^2.1.0"
             }
         },
@@ -5056,11 +5068,11 @@
             "requires": {}
         },
         "@firebase/util": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.4.0.tgz",
-            "integrity": "sha512-z8A+9YGM61ZXQ2KBSVwxXaELOJjG+EQ374YolqNVMvWBJzTNGZGaVP81Ggl8XD10Xinyt1Dgdo86JDV0OAnvqA==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.4.1.tgz",
+            "integrity": "sha512-XhYCOwq4AH+YeQBEnDQvigz50WiiBU4LnJh2+//VMt4J2Ybsk0eTgUHNngUzXsmp80EJrwal3ItODg55q1ajWg==",
             "requires": {
-                "tslib": "^2.0.0"
+                "tslib": "^2.1.0"
             }
         },
         "@firebase/webchannel-wrapper": {
@@ -5175,9 +5187,9 @@
             "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
         },
         "@types/eslint": {
-            "version": "7.2.7",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.7.tgz",
-            "integrity": "sha512-EHXbc1z2GoQRqHaAT7+grxlTJ3WE2YNeD6jlpPoRc83cCoThRY+NUWjCUZaYmk51OICkPXn2hhphcWcWXgNW0Q==",
+            "version": "7.2.8",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.8.tgz",
+            "integrity": "sha512-RTKvBsfz0T8CKOGZMfuluDNyMFHnu5lvNr4hWEsQeHXH6FcmIDIozOyWMh36nLGMwVd5UFNXC2xztA8lln22MQ==",
             "dev": true,
             "requires": {
                 "@types/estree": "*",
@@ -5476,9 +5488,9 @@
             }
         },
         "anymatch": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-            "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+            "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
             "dev": true,
             "requires": {
                 "normalize-path": "^3.0.0",
@@ -5656,9 +5668,9 @@
             "dev": true
         },
         "balanced-match": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
         "base64-js": {
@@ -5772,9 +5784,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001204",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz",
-            "integrity": "sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ==",
+            "version": "1.0.30001207",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz",
+            "integrity": "sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw==",
             "dev": true
         },
         "chai": {
@@ -5978,9 +5990,9 @@
             }
         },
         "copy-webpack-plugin": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-8.1.0.tgz",
-            "integrity": "sha512-Soiq8kXI2AZkpw3dSp18u6oU2JonC7UKv3UdXsKOmT1A5QT46ku9+6c0Qy29JDbSavQJNN1/eKGpd3QNw+cZWg==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-8.1.1.tgz",
+            "integrity": "sha512-rYM2uzRxrLRpcyPqGceRBDpxxUV8vcDqIKxAUKfcnFpcrPxT5+XvhTxv7XLjo5AvEJFPdAE3zCogG2JVahqgSQ==",
             "dev": true,
             "requires": {
                 "fast-glob": "^3.2.5",
@@ -6125,26 +6137,26 @@
             "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q=="
         },
         "domelementtype": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-            "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+            "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
         },
         "domhandler": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-            "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.1.0.tgz",
+            "integrity": "sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==",
             "requires": {
-                "domelementtype": "^2.1.0"
+                "domelementtype": "^2.2.0"
             }
         },
         "domutils": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.0.tgz",
-            "integrity": "sha512-Ho16rzNMOFk2fPwChGh3D2D9OEHAfG19HgmRR2l+WLSsIstNsAYBzePH412bL0y5T44ejABIVfTHQ8nqi/tBCg==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.1.tgz",
+            "integrity": "sha512-hO1XwHMGAthA/1KL7c83oip/6UWo3FlUNIuWiWKltoiQ5oCOiqths8KknvY2jpOohUoUgnwa/+Rm7UpwpSbY/Q==",
             "requires": {
                 "dom-serializer": "^1.0.1",
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.0.0"
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.1.0"
             }
         },
         "ecdsa-sig-formatter": {
@@ -6156,9 +6168,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.702",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.702.tgz",
-            "integrity": "sha512-qJVUKFWQnF6wP7MmTngDkmm8/KPzaiTXNFOAg5j7DSa6J7kPou7mTBqC8jpUOxauQWwHR3pn4dMRdV8IE1xdtA==",
+            "version": "1.3.709",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.709.tgz",
+            "integrity": "sha512-LolItk2/ikSGQ7SN8UkuKVNMBZp3RG7Itgaxj1npsHRzQobj9JjMneZOZfLhtwlYBe5fCJ75k+cVCiDFUs23oA==",
             "dev": true
         },
         "emoji-regex": {
@@ -6207,9 +6219,9 @@
             "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
         },
         "envinfo": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.4.tgz",
-            "integrity": "sha512-TQXTYFVVwwluWSFis6K2XKxgrD22jEv0FTuLCQI+OjH7rn93+iY0fSSFM5lrSxFY+H1+B0/cvvlamr3UsBivdQ==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
+            "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
             "dev": true
         },
         "es-module-lexer": {
@@ -6427,24 +6439,24 @@
             }
         },
         "firebase": {
-            "version": "8.3.1",
-            "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.3.1.tgz",
-            "integrity": "sha512-2BhzHQ8ZDh4BLZ9bicW8FEKFOYmu/w1sKhR5vi4X9SP+dsYNoKyFOP7Sfmk0GoENzt2+Y04GgfS5YERXLQky+w==",
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.3.2.tgz",
+            "integrity": "sha512-qGKASp6lXcV8NriHz/3wdltyLUjHOVkON6TQ1syGjW0sS5q/yTl9LK4O83hDLwG+UeRVRhLOaVa3jaLG4o3gnw==",
             "requires": {
-                "@firebase/analytics": "0.6.6",
-                "@firebase/app": "0.6.17",
+                "@firebase/analytics": "0.6.7",
+                "@firebase/app": "0.6.18",
                 "@firebase/app-types": "0.6.1",
                 "@firebase/auth": "0.16.4",
-                "@firebase/database": "0.9.6",
-                "@firebase/firestore": "2.2.1",
-                "@firebase/functions": "0.6.4",
-                "@firebase/installations": "0.4.22",
-                "@firebase/messaging": "0.7.6",
-                "@firebase/performance": "0.4.8",
+                "@firebase/database": "0.9.7",
+                "@firebase/firestore": "2.2.2",
+                "@firebase/functions": "0.6.5",
+                "@firebase/installations": "0.4.23",
+                "@firebase/messaging": "0.7.7",
+                "@firebase/performance": "0.4.9",
                 "@firebase/polyfill": "0.3.36",
-                "@firebase/remote-config": "0.1.33",
-                "@firebase/storage": "0.4.5",
-                "@firebase/util": "0.4.0"
+                "@firebase/remote-config": "0.1.34",
+                "@firebase/storage": "0.4.6",
+                "@firebase/util": "0.4.1"
             }
         },
         "flat": {
@@ -6896,9 +6908,9 @@
                     },
                     "dependencies": {
                         "domelementtype": {
-                            "version": "2.1.0",
-                            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-                            "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
+                            "version": "2.2.0",
+                            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+                            "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
                             "dev": true
                         },
                         "entities": {
@@ -7198,18 +7210,18 @@
             "dev": true
         },
         "mime-db": {
-            "version": "1.46.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-            "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
+            "version": "1.47.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+            "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.29",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
-            "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+            "version": "2.1.30",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+            "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
             "dev": true,
             "requires": {
-                "mime-db": "1.46.0"
+                "mime-db": "1.47.0"
             }
         },
         "mimic-fn": {
@@ -7532,14 +7544,22 @@
             "peer": true
         },
         "postcss": {
-            "version": "8.2.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.8.tgz",
-            "integrity": "sha512-1F0Xb2T21xET7oQV9eKuctbM9S7BC0fetoHCc4H13z0PT6haiRLP4T0ZY4XWh7iLP0usgqykT6p9B2RtOf4FPw==",
+            "version": "8.2.9",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
+            "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
             "dev": true,
             "requires": {
                 "colorette": "^1.2.2",
-                "nanoid": "^3.1.20",
+                "nanoid": "^3.1.22",
                 "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "nanoid": {
+                    "version": "3.1.22",
+                    "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
+                    "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
+                    "dev": true
+                }
             }
         },
         "postcss-modules-extract-imports": {
@@ -8039,9 +8059,9 @@
             }
         },
         "tslib": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-            "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+            "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
         },
         "type-detect": {
             "version": "4.0.8",
@@ -8125,9 +8145,9 @@
             "dev": true
         },
         "webpack": {
-            "version": "5.28.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.28.0.tgz",
-            "integrity": "sha512-1xllYVmA4dIvRjHzwELgW4KjIU1fW4PEuEnjsylz7k7H5HgPOctIq7W1jrt3sKH9yG5d72//XWzsHhfoWvsQVg==",
+            "version": "5.30.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.30.0.tgz",
+            "integrity": "sha512-Zr9NIri5yzpfmaMea2lSMV1UygbW0zQsSlGLMgKUm63ACXg6alhd1u4v5UBSBjzYKXJN6BNMGVM7w165e7NxYA==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.0",
@@ -8336,9 +8356,9 @@
             "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
         },
         "y18n": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-            "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.7.tgz",
+            "integrity": "sha512-oOhslryvNcA1lB9WYr+M6TMyLkLg81Dgmyb48ZDU0lvR+5bmNDTMz7iobM1QXooaLhbbrcHrlNaABhI6Vo6StQ==",
             "dev": true
         },
         "yallist": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.11.0",
+    "version": "6.12.0",
     "description": "Write everything faster.",
     "scripts": {
         "test": "NODE_OPTIONS='-r esm' webpack -c webpack.test.js && mocha-headless-chrome -f test/index.html",

--- a/safari-extension/Gorgias Templates.xcodeproj/project.pbxproj
+++ b/safari-extension/Gorgias Templates.xcodeproj/project.pbxproj
@@ -457,14 +457,14 @@
 				CODE_SIGN_ENTITLEMENTS = "Gorgias Templates/Gorgias_Templates.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.5;
+				CURRENT_PROJECT_VERSION = 1.6;
 				INFOPLIST_FILE = "Gorgias Templates/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.gorgias.gorgiastemplates;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -480,14 +480,14 @@
 				CODE_SIGN_ENTITLEMENTS = "Gorgias Templates/Gorgias_Templates.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.5;
+				CURRENT_PROJECT_VERSION = 1.6;
 				INFOPLIST_FILE = "Gorgias Templates/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.gorgias.gorgiastemplates;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/src/content/js/autocomplete.js
+++ b/src/content/js/autocomplete.js
@@ -15,6 +15,7 @@ import zendeskPlugin from './plugins/zendesk';
 import draftPlugin from './plugins/draft';
 import prosemirrorPlugin from './plugins/prosemirror';
 import quillPlugin from './plugins/quill';
+import slatePlugin from './plugins/slate';
 import crmPlugin from './plugins/crm';
 import genericPlugin from './plugins/generic';
 
@@ -249,6 +250,7 @@ register(zendeskPlugin);
 register(draftPlugin);
 register(prosemirrorPlugin);
 register(quillPlugin);
+register(slatePlugin);
 register(crmPlugin);
 register(genericPlugin);
 

--- a/src/content/js/dialog.js
+++ b/src/content/js/dialog.js
@@ -168,7 +168,7 @@ var dialog = {
             // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/openPopup
             // Open the browserAction popup in a new tab.
             const popupUrl = browser.runtime.getURL('popup/popup.html');
-            window.open(popupUrl, Config.dashboardTarget);
+            window.open(`${popupUrl}?source=tab`, Config.dashboardTarget);
         });
     },
     setupQuickButton: function () {

--- a/src/content/js/dialog.js
+++ b/src/content/js/dialog.js
@@ -164,18 +164,11 @@ var dialog = {
 
         $dialog.on('mousedown', '.js-gorgias-signin', function () {
             // HACK
-            // we can't re-render the dialog on session success,
-            // because we lost the pointer to the editor element.
-            // we provide immediate feedback by closing the dialog.
-            // BUG requires pressing the sign-in button twice.
-            dialog.close();
-
-            // check session
-            store.getSession()
-                .catch(() => {
-                    // logged-out
-                    window.open(Config.functionsUrl, Config.dashboardTarget);
-                });
+            // browserAction.openPopup is not supported in all browsers yet.
+            // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/openPopup
+            // Open the browserAction popup in a new tab.
+            const popupUrl = browser.runtime.getURL('popup/popup.html');
+            window.open(popupUrl, Config.dashboardTarget);
         });
     },
     setupQuickButton: function () {

--- a/src/content/js/plugins/slate.js
+++ b/src/content/js/plugins/slate.js
@@ -1,0 +1,19 @@
+/* Slate editor plugin
+ */
+
+import {parseTemplate} from '../utils';
+import {isSlate} from '../utils/editor-slate';
+import {insertSlateText} from '../utils/editor-slate';
+
+export default (params = {}) => {
+    if (!isSlate(params.element)) {
+        return false;
+    }
+
+    var parsedTemplate = parseTemplate(params.quicktext.body, {});
+    insertSlateText(Object.assign({
+        text: parsedTemplate
+    }, params));
+
+    return true;
+};

--- a/src/content/js/plugins/zendesk.js
+++ b/src/content/js/plugins/zendesk.js
@@ -59,9 +59,11 @@ export default (params = {}) => {
         return false;
     }
 
+    // TODO getData no longer works
     var data = getData(params);
     var parsedTemplate = parseTemplate(params.quicktext.body, data);
 
+    // TODO use Slate template insert
     insertText(Object.assign({
         text: parsedTemplate
     }, params));

--- a/src/content/js/utils/editor-generic.js
+++ b/src/content/js/utils/editor-generic.js
@@ -62,7 +62,7 @@ export function setCursorPosition (container, node) {
     return {
         range: range,
         focusNode: focusNode
-    }
+    };
 }
 
 export function insertTemplate (params = {}) {

--- a/src/content/js/utils/editor-generic.js
+++ b/src/content/js/utils/editor-generic.js
@@ -4,61 +4,73 @@
 import {isContentEditable} from '../utils';
 import {htmlToText} from './plain-text';
 
+// Set the cursor position at the end of the focusNode.
+// Used when inserting templates with the dialog,
+// and the correct caret position is lost.
+export function setCursorPosition (container, node) {
+    const selection = window.getSelection();
+    let focusNode = node;
+
+    // setStart/setEnd work differently based on
+    // the type of node
+    // https://developer.mozilla.org/en-US/docs/Web/API/range.setStart
+    if (!document.body.contains(focusNode)) {
+        focusNode = selection.focusNode;
+    }
+
+    // Loom browser extension causes the focusNode to always be an element
+    // on certain websites.
+    // we need to have a text node in the end
+    while (focusNode.nodeType === document.ELEMENT_NODE) {
+        if (focusNode.childNodes.length > 0) {
+            // when focusNode can have child nodes,
+            // focusOffset is the index in the childNodes collection
+            // of the focus node where the selection ends.
+            let focusOffset = selection.focusOffset;
+            // *but* if the focus point is placed after the anchor point,
+            // (when we insert templates with the shortcut, not from the dialog),
+            // the focus point is the first position after (not part of the selection),
+            // therefore focusOffset can be equal to the length of focusNode childNodes.
+            if (selection.focusOffset === focusNode.childNodes.length) {
+                focusOffset = selection.focusOffset - 1;
+            }
+            // select a text node
+            focusNode = focusNode.childNodes[focusOffset];
+        } else {
+            // create an empty text node
+            var tempNode = document.createTextNode('');
+
+            // if the focusNode is the same as the container node
+            if (focusNode === container) {
+                // insert it in the node
+                focusNode.appendChild(tempNode);
+            } else {
+                // or attach it before the node
+                focusNode.parentNode.insertBefore(tempNode, focusNode);
+            }
+
+            focusNode = tempNode;
+        }
+    }
+
+    const range = selection.getRangeAt(0);
+    // restore focus to the correct position,
+    // in case we insert templates using the dialog.
+    range.setStartAfter(focusNode);
+    range.collapse();
+
+    return {
+        range: range,
+        focusNode: focusNode
+    }
+}
+
 export function insertTemplate (params = {}) {
     // restore focus to the editable area
     params.element.focus();
 
     if (isContentEditable(params.element)) {
-        const selection = window.getSelection();
-        let focusNode = params.focusNode;
-
-        // setStart/setEnd work differently based on
-        // the type of node
-        // https://developer.mozilla.org/en-US/docs/Web/API/range.setStart
-        if (!document.body.contains(focusNode)) {
-            focusNode = selection.focusNode;
-        }
-
-        // Loom browser extension causes the focusNode to always be an element
-        // on certain websites.
-        // we need to have a text node in the end
-        while (focusNode.nodeType === document.ELEMENT_NODE) {
-            if (focusNode.childNodes.length > 0) {
-                // when focusNode can have child nodes,
-                // focusOffset is the index in the childNodes collection
-                // of the focus node where the selection ends.
-                let focusOffset = selection.focusOffset;
-                // *but* if the focus point is placed after the anchor point,
-                // (when we insert templates with the shortcut, not from the dialog),
-                // the focus point is the first position after (not part of the selection),
-                // therefore focusOffset can be equal to the length of focusNode childNodes.
-                if (selection.focusOffset === focusNode.childNodes.length) {
-                    focusOffset = selection.focusOffset - 1;
-                }
-                // select a text node
-                focusNode = focusNode.childNodes[focusOffset];
-            } else {
-                // create an empty text node
-                var tempNode = document.createTextNode('');
-
-                // if the focusNode is the same as the element
-                if (focusNode === params.element) {
-                    // insert it in the node
-                    focusNode.appendChild(tempNode);
-                } else {
-                    // or attach it before the node
-                    focusNode.parentNode.insertBefore(tempNode, focusNode);
-                }
-
-                focusNode = tempNode;
-            }
-        }
-
-        const range = selection.getRangeAt(0);
-        // restore focus to the correct position,
-        // in case we insert templates using the dialog.
-        range.setStartAfter(focusNode);
-        range.collapse();
+        const {range, focusNode} = setCursorPosition(params.element, params.focusNode);
 
         // delete shortcut
         if (params.word.text === params.quicktext.shortcut) {

--- a/src/content/js/utils/editor-slate.js
+++ b/src/content/js/utils/editor-slate.js
@@ -1,0 +1,93 @@
+/* global InputEvent */
+/* Slate
+ * framework for building rich text editors.
+ * https://github.com/ianstormtaylor/slate
+ */
+
+import {htmlToText} from './plain-text';
+
+export function isSlate (element) {
+    return element.dataset.slateEditor;
+}
+
+export function insertSlateText (params = {}) {
+    params.element.focus();
+
+    // TODO required for restoring the cursor at the correct position
+    // after opening the dialog
+    // TODO BUG can't insert templates with the dialog
+    const selection = window.getSelection();
+    let focusNode = params.focusNode;
+
+    // setStart/setEnd work differently based on
+    // the type of node
+    // https://developer.mozilla.org/en-US/docs/Web/API/range.setStart
+    if (!document.body.contains(focusNode)) {
+        focusNode = selection.focusNode;
+    }
+
+    // Loom browser extension causes the focusNode to always be an element
+    // on certain websites.
+    // we need to have a text node in the end
+    while (focusNode.nodeType === document.ELEMENT_NODE) {
+        if (focusNode.childNodes.length > 0) {
+            // when focusNode can have child nodes,
+            // focusOffset is the index in the childNodes collection
+            // of the focus node where the selection ends.
+            let focusOffset = selection.focusOffset;
+            // *but* if the focus point is placed after the anchor point,
+            // (when we insert templates with the shortcut, not from the dialog),
+            // the focus point is the first position after (not part of the selection),
+            // therefore focusOffset can be equal to the length of focusNode childNodes.
+            if (selection.focusOffset === focusNode.childNodes.length) {
+                focusOffset = selection.focusOffset - 1;
+            }
+            // select a text node
+            focusNode = focusNode.childNodes[focusOffset];
+        } else {
+            // create an empty text node
+            var tempNode = document.createTextNode('');
+
+            // if the focusNode is the same as the element
+            if (focusNode === params.element) {
+                // insert it in the node
+                focusNode.appendChild(tempNode);
+            } else {
+                // or attach it before the node
+                focusNode.parentNode.insertBefore(tempNode, focusNode);
+            }
+
+            focusNode = tempNode;
+        }
+    }
+
+    const range = selection.getRangeAt(0);
+    // restore focus to the correct position,
+    // in case we insert templates using the dialog.
+    range.setStartAfter(focusNode);
+    range.collapse();
+
+    // Slate uses onbeforeinput exclusively, and does not notice content inserted from outside.
+    // https://docs.slatejs.org/concepts/xx-migrating#beforeinput
+    // Use the Slate-specific method to insert and remove text,
+    // using custom synthetic beforeinput events.
+    // The inputType property is specific to Slate:
+    // https://github.com/ianstormtaylor/slate/blob/16ff44d0566889a843a346215d3fb7621fc0ed8c/packages/slate-react/src/components/editable.tsx#L193
+    if (params.word.text === params.quicktext.shortcut) {
+        const deleteWordBackward = new InputEvent('beforeinput', {
+            bubbles: true,
+            // template shortcut will always be the word before the cursor
+            inputType: 'deleteWordBackward'
+        });
+        params.element.dispatchEvent(deleteWordBackward);
+    }
+
+    // only supports plain text
+    const content = htmlToText(params.text);
+    const insertText = new InputEvent('beforeinput', {
+        bubbles: true,
+        inputType: 'insertText',
+        data: content
+    });
+    params.element.dispatchEvent(insertText);
+}

--- a/src/content/js/utils/editor-slate.js
+++ b/src/content/js/utils/editor-slate.js
@@ -5,6 +5,7 @@
  */
 
 import {htmlToText} from './plain-text';
+import {setCursorPosition} from './editor-generic';
 
 export function isSlate (element) {
     return element.dataset.slateEditor;
@@ -13,81 +14,35 @@ export function isSlate (element) {
 export function insertSlateText (params = {}) {
     params.element.focus();
 
-    // TODO required for restoring the cursor at the correct position
-    // after opening the dialog
-    // TODO BUG can't insert templates with the dialog
-    const selection = window.getSelection();
-    let focusNode = params.focusNode;
+    // restore the cursor at the location it was,
+    // before opening the dialog.
+    setCursorPosition(params.element, params.focusNode);
 
-    // setStart/setEnd work differently based on
-    // the type of node
-    // https://developer.mozilla.org/en-US/docs/Web/API/range.setStart
-    if (!document.body.contains(focusNode)) {
-        focusNode = selection.focusNode;
-    }
-
-    // Loom browser extension causes the focusNode to always be an element
-    // on certain websites.
-    // we need to have a text node in the end
-    while (focusNode.nodeType === document.ELEMENT_NODE) {
-        if (focusNode.childNodes.length > 0) {
-            // when focusNode can have child nodes,
-            // focusOffset is the index in the childNodes collection
-            // of the focus node where the selection ends.
-            let focusOffset = selection.focusOffset;
-            // *but* if the focus point is placed after the anchor point,
-            // (when we insert templates with the shortcut, not from the dialog),
-            // the focus point is the first position after (not part of the selection),
-            // therefore focusOffset can be equal to the length of focusNode childNodes.
-            if (selection.focusOffset === focusNode.childNodes.length) {
-                focusOffset = selection.focusOffset - 1;
-            }
-            // select a text node
-            focusNode = focusNode.childNodes[focusOffset];
-        } else {
-            // create an empty text node
-            var tempNode = document.createTextNode('');
-
-            // if the focusNode is the same as the element
-            if (focusNode === params.element) {
-                // insert it in the node
-                focusNode.appendChild(tempNode);
-            } else {
-                // or attach it before the node
-                focusNode.parentNode.insertBefore(tempNode, focusNode);
-            }
-
-            focusNode = tempNode;
+    // Slate won't handle the text manipulation events until it notices we restored focus.
+    // The timeout is required for inserting templates with the dialog.
+    setTimeout(() => {
+        // Slate uses onbeforeinput exclusively, and does not notice content inserted from outside.
+        // https://docs.slatejs.org/concepts/xx-migrating#beforeinput
+        // Use the Slate-specific method to insert and remove text,
+        // using custom synthetic beforeinput events.
+        // The inputType property value is handled by Slate:
+        // https://github.com/ianstormtaylor/slate/blob/16ff44d0566889a843a346215d3fb7621fc0ed8c/packages/slate-react/src/components/editable.tsx#L193
+        if (params.word.text === params.quicktext.shortcut) {
+            const deleteWordBackward = new InputEvent('beforeinput', {
+                bubbles: true,
+                // template shortcut will always be the word before the cursor
+                inputType: 'deleteWordBackward'
+            });
+            params.element.dispatchEvent(deleteWordBackward);
         }
-    }
 
-    const range = selection.getRangeAt(0);
-    // restore focus to the correct position,
-    // in case we insert templates using the dialog.
-    range.setStartAfter(focusNode);
-    range.collapse();
-
-    // Slate uses onbeforeinput exclusively, and does not notice content inserted from outside.
-    // https://docs.slatejs.org/concepts/xx-migrating#beforeinput
-    // Use the Slate-specific method to insert and remove text,
-    // using custom synthetic beforeinput events.
-    // The inputType property is specific to Slate:
-    // https://github.com/ianstormtaylor/slate/blob/16ff44d0566889a843a346215d3fb7621fc0ed8c/packages/slate-react/src/components/editable.tsx#L193
-    if (params.word.text === params.quicktext.shortcut) {
-        const deleteWordBackward = new InputEvent('beforeinput', {
+        // only supports plain text
+        const content = htmlToText(params.text);
+        const insertText = new InputEvent('beforeinput', {
             bubbles: true,
-            // template shortcut will always be the word before the cursor
-            inputType: 'deleteWordBackward'
+            inputType: 'insertText',
+            data: content
         });
-        params.element.dispatchEvent(deleteWordBackward);
-    }
-
-    // only supports plain text
-    const content = htmlToText(params.text);
-    const insertText = new InputEvent('beforeinput', {
-        bubbles: true,
-        inputType: 'insertText',
-        data: content
+        params.element.dispatchEvent(insertText);
     });
-    params.element.dispatchEvent(insertText);
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -36,7 +36,7 @@
         }
     ],
     "web_accessible_resources": [
-        "pages/bg.html"
+        "popup/popup.html"
     ],
     "browser_action": {
         "default_title": "Gorgias Templates",

--- a/src/popup/popup-dashboard.js
+++ b/src/popup/popup-dashboard.js
@@ -103,11 +103,19 @@ customElements.define(
                         ` : ''}
 
                         ${this.isFree === false ? `
-                            <p class="popup-quote">
-                                ${this.stats.words < 1500 ? `Big things have small beginnings &#128170;` : ''}
-                                ${this.stats.words > 1500 && this.stats.words < 2500 ? `Or the equivalent of writing a short story &#128214;` : ''}
-                                ${this.stats.words >= 2500 && this.stats.words < 7500 ? `Did you know mushrooms are one of the largest organisms in the world? &#127812;` : ''}
-                                ${this.stats.words >= 7500 ? `You're awesome. Just awesome. &#9996;` : ''}
+                            <p>
+                                ${this.stats.words < 1500 ? `
+                                    <span class="font-italic">Big things have small beginnings</span> &#128170;
+                                ` : ''}
+                                ${this.stats.words > 1500 && this.stats.words < 2500 ? `
+                                    <span class="font-italic">Or the equivalent of writing a short story</span> &#128214;
+                                ` : ''}
+                                ${this.stats.words >= 2500 && this.stats.words < 7500 ? `
+                                    <span class="font-italic">Did you know mushrooms are one of the largest organisms in the world?</span> &#127812;
+                                ` : ''}
+                                ${this.stats.words >= 7500 ? `
+                                    <span class="font-italic">You're awesome. Just awesome.</span> &#9996;
+                                ` : ''}
                             </p>
                         ` : ''}
 

--- a/src/popup/popup-login-form.js
+++ b/src/popup/popup-login-form.js
@@ -1,3 +1,4 @@
+/* globals REGISTER_DISABLED */
 import Config from '../config';
 import store from '../store/store-client';
 
@@ -62,6 +63,7 @@ customElements.define(
                     </div>
 
                     <div class="form-group">
+                        ${!REGISTER_DISABLED ? `
                         <a
                             href="${Config.functionsUrl}"
                             target="_blank"
@@ -70,6 +72,7 @@ customElements.define(
                             >
                             Forgot password?
                         </a>
+                        ` : ''}
 
                         <label for="login-password">
                             Password

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -7,6 +7,10 @@ html {
    font-size: 14px;
 }
 
+body {
+   background-color: #f7f7f7;
+}
+
 p {
     margin-bottom: .8rem;
 }
@@ -21,6 +25,19 @@ label {
 
 .popup-container {
     width: 22em;
+    margin: 0 auto;
+    background-color: #fff;
+}
+
+@media only screen and (min-width: 42em) {
+    .popup-container {
+        width: 28em;
+        margin-top: 2em;
+        margin-bottom: 2em;
+
+        border-radius: 4px;
+        box-shadow: 0 10px 8px -4px rgb(0 0 0 / 5%);
+    }
 }
 
 .popup-box {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -219,10 +219,6 @@ a,
     margin-bottom: 0;
 }
 
-.popup-quote {
-    font-style: italic;
-}
-
 .popup-status {
     overflow: hidden;
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -15,7 +15,7 @@ customElements.define(
             this.checkLogin();
 
             store.on('login', () => {
-                // close tab when popup is in the new tab
+                // close window when the popup is opened as a new tab, not browser action.
                 // eg. opened from the dialog
                 const urlParams = new URLSearchParams(window.location.search);
                 if (urlParams.get('source') === 'tab') {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,3 +1,4 @@
+/* global URLSearchParams */
 import './popup.css';
 
 import './popup-login';
@@ -13,7 +14,16 @@ customElements.define(
 
             this.checkLogin();
 
-            store.on('login', () => this.checkLogin());
+            store.on('login', () => {
+                // close tab when popup is in the new tab
+                // eg. opened from the dialog
+                const urlParams = new URLSearchParams(window.location.search);
+                if (urlParams.get('source') === 'tab') {
+                    return window.close();
+                }
+
+                return this.checkLogin();
+            });
             store.on('logout', () => this.checkLogin());
         }
         checkLogin() {


### PR DESCRIPTION
#### Changes:
- Support inserting templates in the [Slate](https://github.com/ianstormtaylor/slate) editor.
- Fixes support for Zendesk, which uses Slate.
- Improve variable support in the Zendesk plugin.
- Change the behavior of the Sign-in link in the dialog. It will now open the browser action popup in a new tab.
- Hide the "forgot password" link in Safari, to avoid linking to the external log-in page.
- Improvements to the quote rendering the popup dashboard.